### PR TITLE
feat: external partner API for Scopus publications (API-key auth)

### DIFF
--- a/controllers/admin_api_client_controller.go
+++ b/controllers/admin_api_client_controller.go
@@ -1,0 +1,230 @@
+package controllers
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"fund-management-api/services"
+
+	"github.com/gin-gonic/gin"
+)
+
+// parseClientIDParam reads the :id path param as a client id.
+func parseClientIDParam(c *gin.Context) (uint64, bool) {
+	id, err := strconv.ParseUint(strings.TrimSpace(c.Param("id")), 10, 64)
+	if err != nil || id == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "invalid client id"})
+		return 0, false
+	}
+	return id, true
+}
+
+// GET /api/v1/admin/api-clients
+func AdminListAPIClients(c *gin.Context) {
+	svc := services.NewAPIClientService(nil)
+	clients, err := svc.ListClients()
+	if err != nil {
+		InternalError(c, "api_clients", err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"success": true, "data": clients})
+}
+
+type createAPIClientRequest struct {
+	Name         string   `json:"name"`
+	Description  *string  `json:"description"`
+	ContactEmail *string  `json:"contact_email"`
+	Scopes       []string `json:"scopes"`
+}
+
+// POST /api/v1/admin/api-clients
+func AdminCreateAPIClient(c *gin.Context) {
+	var req createAPIClientRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "invalid request body"})
+		return
+	}
+	if strings.TrimSpace(req.Name) == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "name is required"})
+		return
+	}
+
+	svc := services.NewAPIClientService(nil)
+	client, granted, err := svc.CreateClient(req.Name, req.Description, req.ContactEmail, req.Scopes)
+	if err != nil {
+		if errors.Is(err, services.ErrAPIScopeNotFound) {
+			c.JSON(http.StatusUnprocessableEntity, gin.H{"success": false, "error": "one or more scopes are unknown"})
+			return
+		}
+		InternalError(c, "api_clients", err)
+		return
+	}
+
+	c.JSON(http.StatusCreated, gin.H{
+		"success": true,
+		"data":    gin.H{"client": client, "scopes": granted},
+	})
+}
+
+// GET /api/v1/admin/api-clients/:id
+func AdminGetAPIClient(c *gin.Context) {
+	id, ok := parseClientIDParam(c)
+	if !ok {
+		return
+	}
+	svc := services.NewAPIClientService(nil)
+	client, err := svc.GetClient(id)
+	if err != nil {
+		if errors.Is(err, services.ErrAPIClientNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"success": false, "error": "client not found"})
+			return
+		}
+		InternalError(c, "api_clients", err)
+		return
+	}
+	keys, err := svc.ListKeys(id)
+	if err != nil {
+		InternalError(c, "api_clients", err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"data":    gin.H{"client": client, "keys": keys},
+	})
+}
+
+type updateAPIClientRequest struct {
+	Name         *string   `json:"name"`
+	Description  *string   `json:"description"`
+	ContactEmail *string   `json:"contact_email"`
+	Status       *string   `json:"status"`
+	Scopes       *[]string `json:"scopes"`
+}
+
+// PATCH /api/v1/admin/api-clients/:id
+func AdminUpdateAPIClient(c *gin.Context) {
+	id, ok := parseClientIDParam(c)
+	if !ok {
+		return
+	}
+	var req updateAPIClientRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "invalid request body"})
+		return
+	}
+	if req.Status != nil && *req.Status != "active" && *req.Status != "disabled" {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "status must be 'active' or 'disabled'"})
+		return
+	}
+
+	var scopeCodes []string
+	if req.Scopes != nil {
+		scopeCodes = *req.Scopes
+	}
+
+	svc := services.NewAPIClientService(nil)
+	client, granted, err := svc.UpdateClient(id, req.Name, req.Description, req.ContactEmail, req.Status, scopeCodes)
+	if err != nil {
+		switch {
+		case errors.Is(err, services.ErrAPIClientNotFound):
+			c.JSON(http.StatusNotFound, gin.H{"success": false, "error": "client not found"})
+		case errors.Is(err, services.ErrAPIScopeNotFound):
+			c.JSON(http.StatusUnprocessableEntity, gin.H{"success": false, "error": "one or more scopes are unknown"})
+		default:
+			InternalError(c, "api_clients", err)
+		}
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"data":    gin.H{"client": client, "scopes": granted},
+	})
+}
+
+type issueAPIKeyRequest struct {
+	Label         *string `json:"label"`
+	ExpiresInDays *int    `json:"expires_in_days"`
+}
+
+// POST /api/v1/admin/api-clients/:id/keys
+// Returns the plaintext key exactly once.
+func AdminIssueAPIKey(c *gin.Context) {
+	id, ok := parseClientIDParam(c)
+	if !ok {
+		return
+	}
+	var req issueAPIKeyRequest
+	// Body is optional; ignore bind errors when empty.
+	_ = c.ShouldBindJSON(&req)
+
+	var expiresAt *time.Time
+	if req.ExpiresInDays != nil && *req.ExpiresInDays > 0 {
+		t := time.Now().AddDate(0, 0, *req.ExpiresInDays)
+		expiresAt = &t
+	}
+
+	svc := services.NewAPIClientService(nil)
+	issued, err := svc.IssueKey(id, req.Label, expiresAt)
+	if err != nil {
+		if errors.Is(err, services.ErrAPIClientNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"success": false, "error": "client not found"})
+			return
+		}
+		InternalError(c, "api_clients", err)
+		return
+	}
+
+	c.JSON(http.StatusCreated, gin.H{
+		"success": true,
+		"message": "Store this key now — it will not be shown again.",
+		"data": gin.H{
+			"raw_key": issued.RawKey,
+			"key":     issued.Key,
+		},
+	})
+}
+
+// DELETE /api/v1/admin/api-clients/:id/keys/:keyId
+func AdminRevokeAPIKey(c *gin.Context) {
+	id, ok := parseClientIDParam(c)
+	if !ok {
+		return
+	}
+	keyID, err := strconv.ParseUint(strings.TrimSpace(c.Param("keyId")), 10, 64)
+	if err != nil || keyID == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "invalid key id"})
+		return
+	}
+
+	svc := services.NewAPIClientService(nil)
+	if err := svc.RevokeKey(id, keyID); err != nil {
+		if errors.Is(err, services.ErrAPIClientNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"success": false, "error": "key not found for this client"})
+			return
+		}
+		InternalError(c, "api_clients", err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"success": true})
+}
+
+// GET /api/v1/admin/api-clients/:id/logs?limit=100
+func AdminListAPIClientLogs(c *gin.Context) {
+	id, ok := parseClientIDParam(c)
+	if !ok {
+		return
+	}
+	limit := parseIntOrDefault(c.Query("limit"), 100)
+
+	svc := services.NewAPIClientService(nil)
+	logs, err := svc.ListRequestLogs(id, limit)
+	if err != nil {
+		InternalError(c, "api_clients", err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"success": true, "data": logs})
+}

--- a/controllers/ext_scopus_controller.go
+++ b/controllers/ext_scopus_controller.go
@@ -1,0 +1,131 @@
+package controllers
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"fund-management-api/services"
+
+	"github.com/gin-gonic/gin"
+)
+
+// ExtListScopusPublications is the external (partner) endpoint:
+//
+//	GET /api/ext/v1/scopus/publications?user_ids=1,2,3&year_from=2020&year_to=2024&limit=50&offset=0
+//
+// It returns a flat, paginated list of (faculty member, Scopus publication) rows for the
+// requested users within the inclusive cover-year range. `user_ids` and `year_from` are
+// required; `year_to` defaults to the current year.
+func ExtListScopusPublications(c *gin.Context) {
+	userIDs, err := parseUserIDsParam(c.Query("user_ids"))
+	if err != nil {
+		extValidationError(c, err.Error())
+		return
+	}
+
+	yearFromRaw := strings.TrimSpace(c.Query("year_from"))
+	if yearFromRaw == "" {
+		extValidationError(c, "year_from is required")
+		return
+	}
+	yearFrom, convErr := strconv.Atoi(yearFromRaw)
+	if convErr != nil || yearFrom < 1900 || yearFrom > 3000 {
+		extValidationError(c, "year_from must be a valid 4-digit year")
+		return
+	}
+
+	yearTo := time.Now().Year()
+	if yearToRaw := strings.TrimSpace(c.Query("year_to")); yearToRaw != "" {
+		yt, convErr := strconv.Atoi(yearToRaw)
+		if convErr != nil || yt < 1900 || yt > 3000 {
+			extValidationError(c, "year_to must be a valid 4-digit year")
+			return
+		}
+		yearTo = yt
+	}
+	if yearTo < yearFrom {
+		extValidationError(c, "year_to must be greater than or equal to year_from")
+		return
+	}
+
+	limit := parseIntOrDefault(c.Query("limit"), 50)
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 500 {
+		limit = 500
+	}
+	offset := parseIntOrDefault(c.Query("offset"), 0)
+	if offset < 0 {
+		offset = 0
+	}
+
+	svc := services.NewScopusPublicationService(nil)
+	items, total, err := svc.ListForPartner(userIDs, yearFrom, yearTo, limit, offset)
+	if err != nil {
+		InternalError(c, "ext_scopus", err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"data":    items,
+		"paging": gin.H{
+			"total":  total,
+			"limit":  limit,
+			"offset": offset,
+		},
+		"filters": gin.H{
+			"user_ids":  userIDs,
+			"year_from": yearFrom,
+			"year_to":   yearTo,
+		},
+	})
+}
+
+// parseUserIDsParam parses a required comma-separated list of positive integer user ids.
+func parseUserIDsParam(raw string) ([]uint, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, errExtBadRequest("user_ids is required (comma-separated list of user_id)")
+	}
+	parts := strings.Split(raw, ",")
+	ids := make([]uint, 0, len(parts))
+	seen := map[uint]struct{}{}
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		n, err := strconv.ParseUint(p, 10, 64)
+		if err != nil || n == 0 {
+			return nil, errExtBadRequest("user_ids must contain only positive integers")
+		}
+		id := uint(n)
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	if len(ids) == 0 {
+		return nil, errExtBadRequest("user_ids is required (comma-separated list of user_id)")
+	}
+	return ids, nil
+}
+
+type extBadRequest string
+
+func (e extBadRequest) Error() string   { return string(e) }
+func errExtBadRequest(msg string) error { return extBadRequest(msg) }
+
+// extValidationError returns the standard 422 envelope for invalid input.
+func extValidationError(c *gin.Context, msg string) {
+	c.JSON(http.StatusUnprocessableEntity, gin.H{
+		"success": false,
+		"error":   msg,
+		"code":    "INVALID_PARAMETER",
+	})
+}

--- a/docs/EXTERNAL_API_SCOPUS.md
+++ b/docs/EXTERNAL_API_SCOPUS.md
@@ -1,30 +1,22 @@
-# External API — Scopus Publications
+# External API — Scopus Publications (Consumer Guide)
 
-REST API for external systems to pull faculty members' Scopus publications from the Fund
-Management platform. Authentication is by **API key** (stored hashed in our DB), authorized by
-**scope**, with per-request **audit logging** and **rate limiting**. The design hosts future
-external APIs beyond this first endpoint.
+REST API for pulling faculty members' Scopus publications from the Fund Management platform.
+This guide is for the **calling system's developers**. Authentication is by **API key**, and
+each request returns a flat, paginated list you can store and filter however your system needs.
 
-This document has two parts:
+> You design and create your own storage. This document describes the **API response fields**
+> (the contract). We do not expose our internal database schema — build your tables from the
+> field reference below. A suggested table is included as a starting point.
 
-- **Part A — Consumer guide** (for the calling system's developers) — how to authenticate and
-  call the API.
-- **Part B — Operator guide** (internal) — schema, key issuance, deployment.
-
----
-
-## Part A — Consumer guide
-
-### Base URL
+## Base URL
 
 ```
 https://<host>/api/ext/v1
 ```
 
-All external endpoints live under `/api/ext/v1`. This is versioned; breaking changes ship
-under a new version (`/api/ext/v2`).
+All endpoints are versioned; breaking changes ship under a new version (`/api/ext/v2`).
 
-### Authentication
+## Authentication
 
 Send your API key as a Bearer token on every request:
 
@@ -32,23 +24,23 @@ Send your API key as a Bearer token on every request:
 Authorization: Bearer <your-api-key>
 ```
 
-- The key looks like `fsk_XXXXXXXXXXXXXXXXXXXXXX`. Treat it as a secret — do not embed it in
+- The key looks like `fsk_XXXXXXXXXXXXXXXXXXXXXX`. Treat it as a secret — never embed it in
   front-end code, URLs, or logs.
-- Keys may be rotated: you can be given a new key while the old one still works, then the old
-  one is revoked. Switch to the new key when you receive it.
+- Keys can be rotated: you may receive a new key while the old one still works, then the old one
+  is revoked. Switch when you receive the new one.
 - **HTTPS only** in production.
 
-### Endpoint: List Scopus publications
+## Endpoint: List Scopus publications
 
 ```
 GET /api/ext/v1/scopus/publications
 ```
 
 Returns a **flat, paginated** list — one row per (faculty member, publication). A publication
-co-authored by several faculty members in our system appears once per member. Filter and
-group on your side as needed.
+co-authored by several faculty members in our system appears **once per member**, so the natural
+unique key of a row is `(user_id, eid)`.
 
-**Query parameters**
+### Query parameters
 
 | Param       | Required | Description |
 |-------------|----------|-------------|
@@ -58,17 +50,17 @@ group on your side as needed.
 | `limit`     | ❌       | Page size. Default `50`, max `500`. |
 | `offset`    | ❌       | Rows to skip. Default `0`. |
 
-`user_id`s are the platform's stable primary keys; obtain the mapping (person → `user_id`) from
+`user_id`s are the platform's stable primary keys; obtain the person → `user_id` mapping from
 the platform operator.
 
-**Example request**
+### Example request
 
 ```bash
 curl -H "Authorization: Bearer fsk_XXXXXXXXXXXX" \
   "https://<host>/api/ext/v1/scopus/publications?user_ids=101,102&year_from=2020&year_to=2024&limit=50&offset=0"
 ```
 
-**Example response** `200 OK`
+### Example response `200 OK`
 
 ```json
 {
@@ -82,6 +74,14 @@ curl -H "Authorization: Bearer fsk_XXXXXXXXXXXX" \
       "document_id": 2201,
       "title": "Deep Learning for X",
       "publication_name": "IEEE Access",
+      "abstract": "We propose a method for ...",
+      "aggregation_type": "Journal",
+      "subtype_description": "Article",
+      "eissn": "21693536",
+      "volume": "11",
+      "issue": "3",
+      "authkeywords": "[\"deep learning\",\"x\"]",
+      "openaccess": 1,
       "publication_year": 2023,
       "cover_date": "2023-05-01T00:00:00Z",
       "cited_by": 12,
@@ -91,7 +91,6 @@ curl -H "Authorization: Bearer fsk_XXXXXXXXXXXX" \
       "scopus_url": "https://www.scopus.com/record/display.uri?eid=2-s2.0-85000000000&origin=inward",
       "author_names": "Somchai Jaidee | Jane Doe",
       "affiliation_name": "Khon Kaen University",
-      "conference_name": null,
       "cite_score_quartile": "Q1"
     }
   ],
@@ -100,12 +99,107 @@ curl -H "Authorization: Bearer fsk_XXXXXXXXXXXX" \
 }
 ```
 
-Fields are nullable where the underlying Scopus record is missing them (they are omitted from
-the JSON when empty). Additional fields (conference details, ISSN, affiliations JSON, CiteScore
-metrics, etc.) may be present.
+Nullable fields are **omitted** from the JSON when empty — do not assume every field is present
+on every row.
 
-**Pagination**: use `paging.total` to iterate. Increase `offset` by `limit` until
-`offset >= total`.
+### Response field reference
+
+Each element of `data[]` has the following fields. Use this to design your storage.
+
+**Faculty member (who the publication belongs to)**
+
+| Field | Type | Nullable | Meaning |
+|-------|------|----------|---------|
+| `user_id` | integer | no | Faculty member's ID in our platform. Stable. Part of the row's unique key. |
+| `user_name` | string | no | Display name. |
+| `user_email` | string | no | Email. |
+| `user_scopus_id` | string | yes | The member's Scopus Author ID. |
+
+**Publication (the Scopus document)**
+
+| Field | Type | Nullable | Meaning |
+|-------|------|----------|---------|
+| `document_id` | integer | no | Our internal id for the document. Stable within our system, but prefer `eid` as the cross-system key. |
+| `eid` | string | no | Scopus EID — globally unique per document. **Recommended natural key.** |
+| `scopus_id` | string | yes | Scopus record id (numeric part of the EID). |
+| `scopus_url` | string | yes | Direct link to the Scopus record. |
+| `title` | string | no | Publication title. |
+| `publication_name` | string | yes | Journal / source name. |
+| `publication_year` | integer | yes | Year derived from the cover date. Convenient for filtering. |
+| `cover_date` | datetime (ISO 8601) | yes | Scopus cover date. |
+| `doi` | string | yes | DOI. |
+| `cited_by` | integer | yes | Citation count at time of fetch. |
+| `author_names` | string | yes | All authors, `" | "`-separated (in author order). |
+| `source_id` | string | yes | Scopus source id. |
+
+**Bibliographic detail**
+
+| Field | Type | Nullable | Meaning |
+|-------|------|----------|---------|
+| `abstract` | string | yes | Abstract text. |
+| `aggregation_type` | string | yes | Source type, e.g. `Journal`, `Conference Proceeding`, `Book`. |
+| `subtype` | string | yes | Scopus subtype code, e.g. `ar` (article), `cp` (conference paper), `re` (review). |
+| `subtype_description` | string | yes | Human-readable subtype, e.g. `Article`. |
+| `issn` / `eissn` / `isbn` | string | yes | Serial / book identifiers (digits only, no dash). |
+| `volume` / `issue` | string | yes | Journal volume / issue. |
+| `page_range` | string | yes | Page range, e.g. `120-135`. |
+| `article_number` | string | yes | Article number (used by e-journals instead of page range). |
+| `authkeywords` | string (JSON array) | yes | Author keywords as a JSON-array string, e.g. `["term a","term b"]`. |
+| `fund_acr` | string | yes | Funding body acronym. |
+| `fund_sponsor` | string | yes | Funding sponsor name. |
+| `openaccess` / `openaccess_flag` | integer (0/1) | yes | Open-access indicators. |
+
+**Affiliations** (document-level values are aggregated across authors; `user_affiliation_*` is
+the querying member's own affiliation on this document)
+
+| Field | Type | Nullable | Meaning |
+|-------|------|----------|---------|
+| `affiliation_afid` / `affiliation_name` / `affiliation_city` / `affiliation_country` / `affiliation_url` | string | yes | Document-level affiliation(s). Multiple values are `" | "`-separated. |
+| `affiliations_json` | string (JSON) | yes | Structured list of affiliations, if you want the detail. |
+| `user_affiliation_afid` / `user_affiliation_name` / `user_affiliation_city` / `user_affiliation_country` / `user_affiliation_url` | string | yes | The querying faculty member's affiliation on this document. |
+
+**Conference** (present for conference papers)
+
+| Field | Type | Nullable | Meaning |
+|-------|------|----------|---------|
+| `conference_name` / `conference_venue` / `conference_city` / `conference_country` / `conference_location` | string | yes | Conference details. |
+
+**CiteScore metrics** (journal-level, for the relevant year)
+
+| Field | Type | Nullable | Meaning |
+|-------|------|----------|---------|
+| `cite_score_percentile` | number | yes | CiteScore percentile. |
+| `cite_score_quartile` | string | yes | Quartile, e.g. `Q1`. |
+| `cite_score_status` | string | yes | `Complete` / `In-Progress`. |
+| `cite_score_rank` | integer | yes | Rank within category. |
+
+### Suggested storage on your side (optional — adapt freely)
+
+You own your schema; this is just a convenient starting point. One row per (member, publication),
+keyed on `(user_id, eid)`:
+
+```sql
+CREATE TABLE scopus_publications (
+  user_id           INT          NOT NULL,
+  eid               VARCHAR(64)  NOT NULL,   -- Scopus global id (natural key)
+  scopus_id         VARCHAR(64),
+  scopus_url        VARCHAR(512),
+  title             VARCHAR(1000) NOT NULL,
+  publication_name  VARCHAR(512),
+  publication_year  SMALLINT,
+  cover_date        DATE,
+  doi               VARCHAR(255),
+  cited_by          INT,
+  author_names      TEXT,
+  cite_score_quartile VARCHAR(8),
+  raw_json          JSON,                    -- optional: keep the whole row for fields you skip
+  fetched_at        DATETIME     NOT NULL,
+  PRIMARY KEY (user_id, eid)
+);
+```
+
+Keep only the columns you need; stash the rest in a `raw_json` column if you want to avoid schema
+churn when we add fields. On each sync, upsert on `(user_id, eid)`.
 
 ### Error format
 
@@ -125,88 +219,11 @@ All errors use a consistent envelope:
 | 429  | `RATE_LIMIT_EXCEEDED`  | Too many requests. Respect the `Retry-After` header (seconds). |
 | 500  | —                      | Internal error. |
 
+### Pagination
+
+Use `paging.total` to iterate: increase `offset` by `limit` until `offset >= total`.
+
 ### Rate limiting
 
-Each client is limited to a fixed number of requests per minute (default **100**). Exceeding it
-returns `429` with a `Retry-After` header. Design your integration to page steadily rather than
-burst.
-
----
-
-## Part B — Operator guide (internal)
-
-### Architecture
-
-- Same Go binary as the main API (`cmd/api`); the external group hangs off the router directly
-  as `/api/ext/v1`, so it does **not** use the internal JWT `AuthMiddleware`.
-- Middleware chain on the group (`routes/routes.go`):
-  `ExtRequestLog → RequireHTTPS → APIKeyAuthMiddleware → ExtRateLimit → RequireScope → handler`.
-- Data comes from `ScopusPublicationService.ListForPartner(...)`, which reuses the same
-  (user → scopus_authors via `users.Scopus_id` → scopus_document_authors → scopus_documents)
-  join as the internal dashboard, adding a `user_id IN (...)` and inclusive cover-year filter.
-
-### Database schema (migration `035_20260809_create_api_client_tables.sql`)
-
-| Table               | Purpose |
-|---------------------|---------|
-| `api_clients`       | External systems (name, contact, `status` active/disabled). |
-| `api_scopes`        | Catalog of grantable scopes (e.g. `scopus.publications.read`). |
-| `api_client_scopes` | Which scopes each client holds. |
-| `api_keys`          | Keys per client. **Only the SHA-256 hash is stored**, plus a short `key_prefix` for display. Supports many active keys per client (rotation). |
-| `api_request_logs`  | One row per external request: client, endpoint, requested `user_ids`, year range, HTTP status, IP, latency. **Never stores the key.** |
-
-The migration also seeds the `scopus.publications.read` scope and an admin permission
-`api.clients.manage` (granted to role 3) that gates the management endpoints below.
-
-Apply it like any other migration (see `migrations/README.md`):
-
-```bash
-mysql -u <user> -p<password> <database> < migrations/035_20260809_create_api_client_tables.sql
-```
-
-### Managing clients & keys (admin endpoints)
-
-All require an admin session (JWT) with permission `api.clients.manage`. Base:
-`/api/v1/admin/api-clients`.
-
-| Method & path | Action |
-|---|---|
-| `POST /api/v1/admin/api-clients` | Create a client. Body: `{ "name", "description?", "contact_email?", "scopes": ["scopus.publications.read"] }` |
-| `GET /api/v1/admin/api-clients` | List clients with their scopes. |
-| `GET /api/v1/admin/api-clients/:id` | Client detail + its keys (metadata only). |
-| `PATCH /api/v1/admin/api-clients/:id` | Update `name`/`description`/`contact_email`/`status`, and/or replace `scopes`. |
-| `POST /api/v1/admin/api-clients/:id/keys` | **Issue a key.** Body (optional): `{ "label?", "expires_in_days?" }`. Response returns the plaintext `raw_key` **once** — store it then. |
-| `DELETE /api/v1/admin/api-clients/:id/keys/:keyId` | Revoke a key. |
-| `GET /api/v1/admin/api-clients/:id/logs?limit=100` | Recent audit-log rows for the client. |
-
-**Issue-key response** (the only time the raw key is shown):
-
-```json
-{
-  "success": true,
-  "message": "Store this key now — it will not be shown again.",
-  "data": { "raw_key": "fsk_XXXXXXXXXXXX", "key": { "id": 5, "key_prefix": "fsk_XXXXXXXX", "status": "active", ... } }
-}
-```
-
-**Rotation**: issue a new key, hand it to the consumer, then revoke the old one — no downtime.
-
-### Configuration (env)
-
-| Variable | Default | Purpose |
-|---|---|---|
-| `EXT_API_RATE_LIMIT_PER_MIN` | `100` | Per-client request budget per minute. |
-| `EXT_API_REQUIRE_HTTPS` | `false` | When `true`, reject requests whose `X-Forwarded-Proto` isn't `https`. |
-
-### Deployment notes
-
-- **HTTPS**: terminate TLS at the reverse proxy — that is the primary enforcement point. Set
-  `EXT_API_REQUIRE_HTTPS=true` as an in-app backstop once the proxy sets `X-Forwarded-Proto`.
-- **CORS**: `Authorization` is already an allowed header. If a browser calls the API directly
-  from another origin, add that origin to `ALLOWED_ORIGINS`. Server-to-server callers are
-  unaffected by CORS.
-- **Rate limiting is in-process**: counters reset on restart and are not shared across
-  instances. Fine for a single-process deployment; move to a shared store (e.g. Redis) if the
-  API is scaled horizontally.
-- **Audit log growth**: `api_request_logs` grows one row per request. Add a retention/rotation
-  job if volume is high.
+Each client has a fixed request budget per minute (default **100**). Exceeding it returns `429`
+with a `Retry-After` header (seconds). Page steadily rather than in bursts.

--- a/docs/EXTERNAL_API_SCOPUS.md
+++ b/docs/EXTERNAL_API_SCOPUS.md
@@ -1,0 +1,212 @@
+# External API — Scopus Publications
+
+REST API for external systems to pull faculty members' Scopus publications from the Fund
+Management platform. Authentication is by **API key** (stored hashed in our DB), authorized by
+**scope**, with per-request **audit logging** and **rate limiting**. The design hosts future
+external APIs beyond this first endpoint.
+
+This document has two parts:
+
+- **Part A — Consumer guide** (for the calling system's developers) — how to authenticate and
+  call the API.
+- **Part B — Operator guide** (internal) — schema, key issuance, deployment.
+
+---
+
+## Part A — Consumer guide
+
+### Base URL
+
+```
+https://<host>/api/ext/v1
+```
+
+All external endpoints live under `/api/ext/v1`. This is versioned; breaking changes ship
+under a new version (`/api/ext/v2`).
+
+### Authentication
+
+Send your API key as a Bearer token on every request:
+
+```
+Authorization: Bearer <your-api-key>
+```
+
+- The key looks like `fsk_XXXXXXXXXXXXXXXXXXXXXX`. Treat it as a secret — do not embed it in
+  front-end code, URLs, or logs.
+- Keys may be rotated: you can be given a new key while the old one still works, then the old
+  one is revoked. Switch to the new key when you receive it.
+- **HTTPS only** in production.
+
+### Endpoint: List Scopus publications
+
+```
+GET /api/ext/v1/scopus/publications
+```
+
+Returns a **flat, paginated** list — one row per (faculty member, publication). A publication
+co-authored by several faculty members in our system appears once per member. Filter and
+group on your side as needed.
+
+**Query parameters**
+
+| Param       | Required | Description |
+|-------------|----------|-------------|
+| `user_ids`  | ✅       | Comma-separated list of faculty `user_id`s (our system's IDs). Duplicates ignored. |
+| `year_from` | ✅       | Start year (inclusive), 4 digits. Based on the publication's Scopus cover date. |
+| `year_to`   | ❌       | End year (inclusive). Defaults to the current year. |
+| `limit`     | ❌       | Page size. Default `50`, max `500`. |
+| `offset`    | ❌       | Rows to skip. Default `0`. |
+
+`user_id`s are the platform's stable primary keys; obtain the mapping (person → `user_id`) from
+the platform operator.
+
+**Example request**
+
+```bash
+curl -H "Authorization: Bearer fsk_XXXXXXXXXXXX" \
+  "https://<host>/api/ext/v1/scopus/publications?user_ids=101,102&year_from=2020&year_to=2024&limit=50&offset=0"
+```
+
+**Example response** `200 OK`
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "user_id": 101,
+      "user_name": "Somchai Jaidee",
+      "user_email": "somchai@kku.ac.th",
+      "user_scopus_id": "55680000000",
+      "document_id": 2201,
+      "title": "Deep Learning for X",
+      "publication_name": "IEEE Access",
+      "publication_year": 2023,
+      "cover_date": "2023-05-01T00:00:00Z",
+      "cited_by": 12,
+      "doi": "10.1109/ACCESS.2023.0000000",
+      "eid": "2-s2.0-85000000000",
+      "scopus_id": "85000000000",
+      "scopus_url": "https://www.scopus.com/record/display.uri?eid=2-s2.0-85000000000&origin=inward",
+      "author_names": "Somchai Jaidee | Jane Doe",
+      "affiliation_name": "Khon Kaen University",
+      "conference_name": null,
+      "cite_score_quartile": "Q1"
+    }
+  ],
+  "paging": { "total": 240, "limit": 50, "offset": 0 },
+  "filters": { "user_ids": [101, 102], "year_from": 2020, "year_to": 2024 }
+}
+```
+
+Fields are nullable where the underlying Scopus record is missing them (they are omitted from
+the JSON when empty). Additional fields (conference details, ISSN, affiliations JSON, CiteScore
+metrics, etc.) may be present.
+
+**Pagination**: use `paging.total` to iterate. Increase `offset` by `limit` until
+`offset >= total`.
+
+### Error format
+
+All errors use a consistent envelope:
+
+```json
+{ "success": false, "error": "<message>", "code": "<CODE>" }
+```
+
+| HTTP | `code`                 | Meaning |
+|------|------------------------|---------|
+| 401  | `MISSING_API_KEY`      | No `Authorization: Bearer` header. |
+| 401  | `INVALID_API_KEY`      | Key unknown, revoked, or expired. |
+| 403  | `INSUFFICIENT_SCOPE`   | Key is valid but lacks the required scope. |
+| 403  | `HTTPS_REQUIRED`       | Request was not over HTTPS (when enforced). |
+| 422  | `INVALID_PARAMETER`    | Missing/invalid `user_ids`, `year_from`, `year_to`, etc. |
+| 429  | `RATE_LIMIT_EXCEEDED`  | Too many requests. Respect the `Retry-After` header (seconds). |
+| 500  | —                      | Internal error. |
+
+### Rate limiting
+
+Each client is limited to a fixed number of requests per minute (default **100**). Exceeding it
+returns `429` with a `Retry-After` header. Design your integration to page steadily rather than
+burst.
+
+---
+
+## Part B — Operator guide (internal)
+
+### Architecture
+
+- Same Go binary as the main API (`cmd/api`); the external group hangs off the router directly
+  as `/api/ext/v1`, so it does **not** use the internal JWT `AuthMiddleware`.
+- Middleware chain on the group (`routes/routes.go`):
+  `ExtRequestLog → RequireHTTPS → APIKeyAuthMiddleware → ExtRateLimit → RequireScope → handler`.
+- Data comes from `ScopusPublicationService.ListForPartner(...)`, which reuses the same
+  (user → scopus_authors via `users.Scopus_id` → scopus_document_authors → scopus_documents)
+  join as the internal dashboard, adding a `user_id IN (...)` and inclusive cover-year filter.
+
+### Database schema (migration `035_20260809_create_api_client_tables.sql`)
+
+| Table               | Purpose |
+|---------------------|---------|
+| `api_clients`       | External systems (name, contact, `status` active/disabled). |
+| `api_scopes`        | Catalog of grantable scopes (e.g. `scopus.publications.read`). |
+| `api_client_scopes` | Which scopes each client holds. |
+| `api_keys`          | Keys per client. **Only the SHA-256 hash is stored**, plus a short `key_prefix` for display. Supports many active keys per client (rotation). |
+| `api_request_logs`  | One row per external request: client, endpoint, requested `user_ids`, year range, HTTP status, IP, latency. **Never stores the key.** |
+
+The migration also seeds the `scopus.publications.read` scope and an admin permission
+`api.clients.manage` (granted to role 3) that gates the management endpoints below.
+
+Apply it like any other migration (see `migrations/README.md`):
+
+```bash
+mysql -u <user> -p<password> <database> < migrations/035_20260809_create_api_client_tables.sql
+```
+
+### Managing clients & keys (admin endpoints)
+
+All require an admin session (JWT) with permission `api.clients.manage`. Base:
+`/api/v1/admin/api-clients`.
+
+| Method & path | Action |
+|---|---|
+| `POST /api/v1/admin/api-clients` | Create a client. Body: `{ "name", "description?", "contact_email?", "scopes": ["scopus.publications.read"] }` |
+| `GET /api/v1/admin/api-clients` | List clients with their scopes. |
+| `GET /api/v1/admin/api-clients/:id` | Client detail + its keys (metadata only). |
+| `PATCH /api/v1/admin/api-clients/:id` | Update `name`/`description`/`contact_email`/`status`, and/or replace `scopes`. |
+| `POST /api/v1/admin/api-clients/:id/keys` | **Issue a key.** Body (optional): `{ "label?", "expires_in_days?" }`. Response returns the plaintext `raw_key` **once** — store it then. |
+| `DELETE /api/v1/admin/api-clients/:id/keys/:keyId` | Revoke a key. |
+| `GET /api/v1/admin/api-clients/:id/logs?limit=100` | Recent audit-log rows for the client. |
+
+**Issue-key response** (the only time the raw key is shown):
+
+```json
+{
+  "success": true,
+  "message": "Store this key now — it will not be shown again.",
+  "data": { "raw_key": "fsk_XXXXXXXXXXXX", "key": { "id": 5, "key_prefix": "fsk_XXXXXXXX", "status": "active", ... } }
+}
+```
+
+**Rotation**: issue a new key, hand it to the consumer, then revoke the old one — no downtime.
+
+### Configuration (env)
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `EXT_API_RATE_LIMIT_PER_MIN` | `100` | Per-client request budget per minute. |
+| `EXT_API_REQUIRE_HTTPS` | `false` | When `true`, reject requests whose `X-Forwarded-Proto` isn't `https`. |
+
+### Deployment notes
+
+- **HTTPS**: terminate TLS at the reverse proxy — that is the primary enforcement point. Set
+  `EXT_API_REQUIRE_HTTPS=true` as an in-app backstop once the proxy sets `X-Forwarded-Proto`.
+- **CORS**: `Authorization` is already an allowed header. If a browser calls the API directly
+  from another origin, add that origin to `ALLOWED_ORIGINS`. Server-to-server callers are
+  unaffected by CORS.
+- **Rate limiting is in-process**: counters reset on restart and are not shared across
+  instances. Fine for a single-process deployment; move to a shared store (e.g. Redis) if the
+  API is scaled horizontally.
+- **Audit log growth**: `api_request_logs` grows one row per request. Add a retention/rotation
+  job if volume is high.

--- a/docs/EXTERNAL_API_SCOPUS_INTERNAL.md
+++ b/docs/EXTERNAL_API_SCOPUS_INTERNAL.md
@@ -1,0 +1,82 @@
+# External Scopus API — Operator Guide (INTERNAL)
+
+Internal companion to `EXTERNAL_API_SCOPUS.md`. **Do not hand this file to external partners** —
+it describes our internal schema, key issuance, and deployment. Give partners only the consumer
+guide.
+
+## Architecture
+
+- Same Go binary as the main API (`cmd/api`); the external group hangs off the router directly as
+  `/api/ext/v1`, so it does **not** use the internal JWT `AuthMiddleware`.
+- Middleware chain on the group (`routes/routes.go`):
+  `ExtRequestLog → RequireHTTPS → APIKeyAuthMiddleware → ExtRateLimit → RequireScope → handler`.
+- Data comes from `ScopusPublicationService.ListForPartner(...)`, which reuses the same
+  (user → `scopus_authors` via `users.Scopus_id` → `scopus_document_authors` → `scopus_documents`)
+  join as the internal dashboard, adding a `user_id IN (...)` and inclusive cover-year filter.
+  Existing service methods are untouched.
+
+## Database schema (migration `035_20260809_create_api_client_tables.sql`)
+
+| Table               | Purpose |
+|---------------------|---------|
+| `api_clients`       | External systems (name, contact, `status` active/disabled). |
+| `api_scopes`        | Catalog of grantable scopes (e.g. `scopus.publications.read`). |
+| `api_client_scopes` | Which scopes each client holds. |
+| `api_keys`          | Keys per client. **Only the SHA-256 hash is stored**, plus a short `key_prefix` for display. Supports many active keys per client (rotation). |
+| `api_request_logs`  | One row per external request: client, endpoint, requested `user_ids`, year range, HTTP status, IP, latency. **Never stores the key.** |
+
+The migration also seeds the `scopus.publications.read` scope and an admin permission
+`api.clients.manage` (granted to role 3) that gates the management endpoints below.
+
+Apply it like any other migration (see `migrations/README.md`):
+
+```bash
+mysql -u <user> -p<password> <database> < migrations/035_20260809_create_api_client_tables.sql
+```
+
+## Managing clients & keys (admin endpoints)
+
+All require an admin session (JWT) with permission `api.clients.manage`. Base:
+`/api/v1/admin/api-clients`.
+
+| Method & path | Action |
+|---|---|
+| `POST /api/v1/admin/api-clients` | Create a client. Body: `{ "name", "description?", "contact_email?", "scopes": ["scopus.publications.read"] }` |
+| `GET /api/v1/admin/api-clients` | List clients with their scopes. |
+| `GET /api/v1/admin/api-clients/:id` | Client detail + its keys (metadata only). |
+| `PATCH /api/v1/admin/api-clients/:id` | Update `name`/`description`/`contact_email`/`status`, and/or replace `scopes`. |
+| `POST /api/v1/admin/api-clients/:id/keys` | **Issue a key.** Body (optional): `{ "label?", "expires_in_days?" }`. Response returns the plaintext `raw_key` **once** — store it then. |
+| `DELETE /api/v1/admin/api-clients/:id/keys/:keyId` | Revoke a key. |
+| `GET /api/v1/admin/api-clients/:id/logs?limit=100` | Recent audit-log rows for the client. |
+
+**Issue-key response** (the only time the raw key is shown):
+
+```json
+{
+  "success": true,
+  "message": "Store this key now — it will not be shown again.",
+  "data": { "raw_key": "fsk_XXXXXXXXXXXX", "key": { "id": 5, "key_prefix": "fsk_XXXXXXXX", "status": "active" } }
+}
+```
+
+**Rotation**: issue a new key, hand it to the consumer, then revoke the old one — no downtime.
+
+## Configuration (env)
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `EXT_API_RATE_LIMIT_PER_MIN` | `100` | Per-client request budget per minute. |
+| `EXT_API_REQUIRE_HTTPS` | `false` | When `true`, reject requests whose `X-Forwarded-Proto` isn't `https`. |
+
+## Deployment notes
+
+- **HTTPS**: terminate TLS at the reverse proxy — that is the primary enforcement point. Set
+  `EXT_API_REQUIRE_HTTPS=true` as an in-app backstop once the proxy sets `X-Forwarded-Proto`.
+- **CORS**: `Authorization` is already an allowed header. If a browser calls the API directly from
+  another origin, add that origin to `ALLOWED_ORIGINS`. Server-to-server callers are unaffected by
+  CORS.
+- **Rate limiting is in-process**: counters reset on restart and are not shared across instances.
+  Fine for a single-process deployment; move to a shared store (e.g. Redis) if the API is scaled
+  horizontally.
+- **Audit log growth**: `api_request_logs` grows one row per request. Add a retention/rotation job
+  if volume is high.

--- a/middleware/api_key_auth.go
+++ b/middleware/api_key_auth.go
@@ -1,0 +1,310 @@
+package middleware
+
+import (
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"fund-management-api/models"
+	"fund-management-api/services"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Gin context keys set by APIKeyAuthMiddleware and consumed by RequireScope / ExtRequestLog.
+const (
+	ctxAPIClientID = "apiClientID" // uint64
+	ctxAPIKeyID    = "apiKeyID"    // uint64
+	ctxAPIScopes   = "apiScopes"   // []string
+)
+
+// APIKeyAuthMiddleware authenticates external clients via `Authorization: Bearer <key>`.
+// On success it stores the client id, key id, and granted scopes in the gin context.
+// Every failure returns 401 with the standard error envelope and does not distinguish
+// between an unknown, revoked, or expired key.
+func APIKeyAuthMiddleware() gin.HandlerFunc {
+	svc := services.NewAPIClientService(nil)
+	return func(c *gin.Context) {
+		raw := extractBearerToken(c)
+		if raw == "" {
+			c.JSON(http.StatusUnauthorized, gin.H{
+				"success": false,
+				"error":   "Missing API key. Send it as 'Authorization: Bearer <key>'.",
+				"code":    "MISSING_API_KEY",
+			})
+			c.Abort()
+			return
+		}
+
+		verified, err := svc.VerifyAPIKey(raw)
+		if err != nil {
+			c.JSON(http.StatusUnauthorized, gin.H{
+				"success": false,
+				"error":   "Invalid or expired API key.",
+				"code":    "INVALID_API_KEY",
+			})
+			c.Abort()
+			return
+		}
+
+		c.Set(ctxAPIClientID, verified.Client.ID)
+		c.Set(ctxAPIKeyID, verified.Key.ID)
+		c.Set(ctxAPIScopes, verified.Scopes)
+		c.Next()
+	}
+}
+
+// RequireScope allows the request through when the authenticated client holds ANY one of the
+// listed scope codes (OR semantics, mirroring RequirePermission). Otherwise it returns 403.
+func RequireScope(scopeCodes ...string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if len(scopeCodes) == 0 {
+			c.Next()
+			return
+		}
+
+		scopesVal, ok := c.Get(ctxAPIScopes)
+		if !ok {
+			c.JSON(http.StatusForbidden, gin.H{
+				"success": false,
+				"error":   "API authorization context not found.",
+				"code":    "AUTH_CONTEXT_MISSING",
+			})
+			c.Abort()
+			return
+		}
+		granted, _ := scopesVal.([]string)
+
+		for _, required := range scopeCodes {
+			for _, have := range granted {
+				if strings.EqualFold(strings.TrimSpace(have), strings.TrimSpace(required)) {
+					c.Next()
+					return
+				}
+			}
+		}
+
+		c.JSON(http.StatusForbidden, gin.H{
+			"success": false,
+			"error":   "This API key is not authorized for the requested resource.",
+			"code":    "INSUFFICIENT_SCOPE",
+			"detail":  strings.Join(scopeCodes, ", "),
+		})
+		c.Abort()
+	}
+}
+
+// --- Rate limiting (per-client, in-memory token bucket) ---
+//
+// NOTE: this limiter is in-process only — its counters reset on restart and are NOT shared
+// across multiple instances. That is fine for the current single-process deployment; if the
+// API is ever scaled horizontally, move this to a shared store (e.g. Redis).
+
+type tokenBucket struct {
+	tokens     float64
+	lastRefill time.Time
+}
+
+type clientRateLimiter struct {
+	mu       sync.Mutex
+	buckets  map[uint64]*tokenBucket
+	capacity float64
+	perSec   float64 // refill rate (tokens per second)
+}
+
+var (
+	extRateLimiterOnce sync.Once
+	extRateLimiter     *clientRateLimiter
+)
+
+func getExtRateLimiter() *clientRateLimiter {
+	extRateLimiterOnce.Do(func() {
+		perMin := envIntDefault("EXT_API_RATE_LIMIT_PER_MIN", 100)
+		if perMin <= 0 {
+			perMin = 100
+		}
+		extRateLimiter = &clientRateLimiter{
+			buckets:  make(map[uint64]*tokenBucket),
+			capacity: float64(perMin),
+			perSec:   float64(perMin) / 60.0,
+		}
+	})
+	return extRateLimiter
+}
+
+// allow consumes one token for the client, returning (allowed, retryAfterSeconds).
+func (l *clientRateLimiter) allow(clientID uint64) (bool, int) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	now := time.Now()
+	b, ok := l.buckets[clientID]
+	if !ok {
+		b = &tokenBucket{tokens: l.capacity, lastRefill: now}
+		l.buckets[clientID] = b
+	}
+
+	// Refill based on elapsed time, capped at capacity.
+	elapsed := now.Sub(b.lastRefill).Seconds()
+	b.tokens += elapsed * l.perSec
+	if b.tokens > l.capacity {
+		b.tokens = l.capacity
+	}
+	b.lastRefill = now
+
+	if b.tokens >= 1 {
+		b.tokens--
+		return true, 0
+	}
+
+	// Seconds until the next whole token is available.
+	retry := int((1.0-b.tokens)/l.perSec) + 1
+	return false, retry
+}
+
+// ExtRateLimit enforces the per-client request budget. It must run AFTER APIKeyAuthMiddleware
+// so the client id is available.
+func ExtRateLimit() gin.HandlerFunc {
+	limiter := getExtRateLimiter()
+	return func(c *gin.Context) {
+		clientID, ok := clientIDFromContext(c)
+		if !ok {
+			// No authenticated client (should not happen after auth) — let it through; the
+			// downstream handler / auth will reject appropriately.
+			c.Next()
+			return
+		}
+		allowed, retryAfter := limiter.allow(clientID)
+		if !allowed {
+			c.Header("Retry-After", strconv.Itoa(retryAfter))
+			c.JSON(http.StatusTooManyRequests, gin.H{
+				"success": false,
+				"error":   "Rate limit exceeded. Slow down and retry later.",
+				"code":    "RATE_LIMIT_EXCEEDED",
+			})
+			c.Abort()
+			return
+		}
+		c.Next()
+	}
+}
+
+// --- Audit logging ---
+
+// ExtRequestLog records one row per external API request AFTER it completes. It captures the
+// client, endpoint, requested filters and outcome — never the API key itself. Writes happen
+// on a background goroutine so logging never adds latency to the response.
+func ExtRequestLog() gin.HandlerFunc {
+	svc := services.NewAPIClientService(nil)
+	return func(c *gin.Context) {
+		start := time.Now()
+		c.Next()
+
+		latency := uint32(time.Since(start).Milliseconds())
+		entry := models.APIRequestLog{
+			Method:     c.Request.Method,
+			Endpoint:   c.Request.URL.Path,
+			HTTPStatus: uint16(c.Writer.Status()),
+			LatencyMs:  &latency,
+		}
+		if ip := c.ClientIP(); ip != "" {
+			entry.IP = &ip
+		}
+		if clientID, ok := clientIDFromContext(c); ok {
+			entry.ClientID = &clientID
+		}
+		if v, ok := c.Get(ctxAPIKeyID); ok {
+			if keyID, ok2 := v.(uint64); ok2 {
+				entry.APIKeyID = &keyID
+			}
+		}
+		if uids := strings.TrimSpace(c.Query("user_ids")); uids != "" {
+			entry.RequestedUserIDs = &uids
+		}
+		if yf := parseYearQuery(c.Query("year_from")); yf != nil {
+			entry.YearFrom = yf
+		}
+		if yt := parseYearQuery(c.Query("year_to")); yt != nil {
+			entry.YearTo = yt
+		}
+
+		go func(e models.APIRequestLog) {
+			_ = svc.WriteRequestLog(&e)
+		}(entry)
+	}
+}
+
+// RequireHTTPS rejects plaintext requests when EXT_API_REQUIRE_HTTPS=true, trusting the
+// reverse proxy's X-Forwarded-Proto header. Off by default — TLS is normally terminated at
+// the proxy, which is the primary enforcement point.
+func RequireHTTPS() gin.HandlerFunc {
+	enabled := strings.EqualFold(strings.TrimSpace(os.Getenv("EXT_API_REQUIRE_HTTPS")), "true")
+	return func(c *gin.Context) {
+		if !enabled {
+			c.Next()
+			return
+		}
+		proto := c.GetHeader("X-Forwarded-Proto")
+		if proto == "" && c.Request.TLS != nil {
+			proto = "https"
+		}
+		if !strings.EqualFold(proto, "https") {
+			c.JSON(http.StatusForbidden, gin.H{
+				"success": false,
+				"error":   "HTTPS is required for this API.",
+				"code":    "HTTPS_REQUIRED",
+			})
+			c.Abort()
+			return
+		}
+		c.Next()
+	}
+}
+
+// --- helpers ---
+
+func extractBearerToken(c *gin.Context) string {
+	header := strings.TrimSpace(c.GetHeader("Authorization"))
+	if header == "" {
+		return ""
+	}
+	parts := strings.SplitN(header, " ", 2)
+	if len(parts) == 2 && strings.EqualFold(parts[0], "Bearer") {
+		return strings.TrimSpace(parts[1])
+	}
+	return ""
+}
+
+func clientIDFromContext(c *gin.Context) (uint64, bool) {
+	v, ok := c.Get(ctxAPIClientID)
+	if !ok {
+		return 0, false
+	}
+	id, ok := v.(uint64)
+	return id, ok
+}
+
+func parseYearQuery(v string) *uint16 {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return nil
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 0 || n > 65535 {
+		return nil
+	}
+	y := uint16(n)
+	return &y
+}
+
+func envIntDefault(key string, def int) int {
+	if raw := strings.TrimSpace(os.Getenv(key)); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil {
+			return n
+		}
+	}
+	return def
+}

--- a/migrations/035_20260809_create_api_client_tables.sql
+++ b/migrations/035_20260809_create_api_client_tables.sql
@@ -1,0 +1,97 @@
+-- External / partner API subsystem.
+-- Authenticates external systems via API keys (stored as SHA-256 hash, never plaintext),
+-- authorized by scope, with per-request audit logging. Designed to host future external
+-- APIs beyond the initial Scopus publications endpoint.
+
+CREATE TABLE IF NOT EXISTS api_clients (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  name VARCHAR(255) NOT NULL,
+  description TEXT DEFAULT NULL,
+  contact_email VARCHAR(255) DEFAULT NULL,
+  status ENUM('active','disabled') NOT NULL DEFAULT 'active',
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  KEY idx_api_clients_status (status)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS api_scopes (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  code VARCHAR(128) NOT NULL,
+  description VARCHAR(255) DEFAULT NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  UNIQUE KEY uq_api_scopes_code (code)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS api_client_scopes (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  client_id BIGINT UNSIGNED NOT NULL,
+  scope_id BIGINT UNSIGNED NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  UNIQUE KEY uq_api_client_scope (client_id, scope_id),
+  KEY idx_api_client_scopes_scope (scope_id),
+  CONSTRAINT fk_api_client_scopes_client FOREIGN KEY (client_id) REFERENCES api_clients (id) ON DELETE CASCADE,
+  CONSTRAINT fk_api_client_scopes_scope FOREIGN KEY (scope_id) REFERENCES api_scopes (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Only the SHA-256 hash of a key is stored. Multiple active keys per client are allowed
+-- so a key can be rotated (issue new, revoke old) with zero downtime.
+CREATE TABLE IF NOT EXISTS api_keys (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  client_id BIGINT UNSIGNED NOT NULL,
+  label VARCHAR(255) DEFAULT NULL,
+  key_prefix VARCHAR(16) NOT NULL,
+  key_hash CHAR(64) NOT NULL,
+  status ENUM('active','revoked') NOT NULL DEFAULT 'active',
+  expires_at DATETIME DEFAULT NULL,
+  last_used_at DATETIME DEFAULT NULL,
+  revoked_at DATETIME DEFAULT NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  UNIQUE KEY uq_api_keys_hash (key_hash),
+  KEY idx_api_keys_client (client_id),
+  KEY idx_api_keys_prefix (key_prefix),
+  CONSTRAINT fk_api_keys_client FOREIGN KEY (client_id) REFERENCES api_clients (id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Append-only audit log. Intentionally has no FK to api_clients/api_keys so that a log
+-- insert never fails and history survives client/key deletion. The API key value is
+-- never stored here.
+CREATE TABLE IF NOT EXISTS api_request_logs (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  client_id BIGINT UNSIGNED DEFAULT NULL,
+  api_key_id BIGINT UNSIGNED DEFAULT NULL,
+  method VARCHAR(8) NOT NULL,
+  endpoint VARCHAR(255) NOT NULL,
+  requested_user_ids TEXT DEFAULT NULL,
+  year_from SMALLINT UNSIGNED DEFAULT NULL,
+  year_to SMALLINT UNSIGNED DEFAULT NULL,
+  http_status SMALLINT UNSIGNED NOT NULL,
+  ip VARCHAR(64) DEFAULT NULL,
+  latency_ms INT UNSIGNED DEFAULT NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  KEY idx_api_request_logs_client (client_id),
+  KEY idx_api_request_logs_created (created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Seed the scope catalog.
+INSERT INTO api_scopes (code, description)
+VALUES ('scopus.publications.read', 'Read Scopus publications of faculty members via the external API')
+ON DUPLICATE KEY UPDATE description = VALUES(description);
+
+-- Seed the admin permission that gates management of API clients/keys (mirrors migration 003).
+INSERT INTO permissions (code, resource, action, description)
+VALUES ('api.clients.manage', 'api_clients', 'manage', 'Manage external API clients and keys')
+ON DUPLICATE KEY UPDATE
+  resource = VALUES(resource),
+  action = VALUES(action),
+  description = VALUES(description),
+  update_at = CURRENT_TIMESTAMP;
+
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT 3, p.permission_id FROM permissions p WHERE p.code = 'api.clients.manage'
+ON DUPLICATE KEY UPDATE update_at = CURRENT_TIMESTAMP;

--- a/models/api_client.go
+++ b/models/api_client.go
@@ -1,0 +1,73 @@
+package models
+
+import "time"
+
+// APIClient is an external system authorized to call the /api/ext APIs.
+type APIClient struct {
+	ID           uint64    `gorm:"primaryKey;column:id" json:"id"`
+	Name         string    `gorm:"column:name" json:"name"`
+	Description  *string   `gorm:"column:description" json:"description,omitempty"`
+	ContactEmail *string   `gorm:"column:contact_email" json:"contact_email,omitempty"`
+	Status       string    `gorm:"column:status" json:"status"` // active | disabled
+	CreatedAt    time.Time `gorm:"column:created_at" json:"created_at"`
+	UpdatedAt    time.Time `gorm:"column:updated_at" json:"updated_at"`
+}
+
+func (APIClient) TableName() string { return "api_clients" }
+
+// APIScope is a catalog entry describing a permission that can be granted to a client.
+type APIScope struct {
+	ID          uint64    `gorm:"primaryKey;column:id" json:"id"`
+	Code        string    `gorm:"column:code" json:"code"`
+	Description *string   `gorm:"column:description" json:"description,omitempty"`
+	CreatedAt   time.Time `gorm:"column:created_at" json:"created_at"`
+}
+
+func (APIScope) TableName() string { return "api_scopes" }
+
+// APIClientScope grants a single scope to a single client.
+type APIClientScope struct {
+	ID        uint64    `gorm:"primaryKey;column:id" json:"id"`
+	ClientID  uint64    `gorm:"column:client_id" json:"client_id"`
+	ScopeID   uint64    `gorm:"column:scope_id" json:"scope_id"`
+	CreatedAt time.Time `gorm:"column:created_at" json:"created_at"`
+}
+
+func (APIClientScope) TableName() string { return "api_client_scopes" }
+
+// APIKey is a credential belonging to a client. Only the SHA-256 hash of the raw key is
+// stored; the plaintext key is shown once at creation and never persisted.
+type APIKey struct {
+	ID         uint64     `gorm:"primaryKey;column:id" json:"id"`
+	ClientID   uint64     `gorm:"column:client_id" json:"client_id"`
+	Label      *string    `gorm:"column:label" json:"label,omitempty"`
+	KeyPrefix  string     `gorm:"column:key_prefix" json:"key_prefix"`
+	KeyHash    string     `gorm:"column:key_hash" json:"-"`
+	Status     string     `gorm:"column:status" json:"status"` // active | revoked
+	ExpiresAt  *time.Time `gorm:"column:expires_at" json:"expires_at,omitempty"`
+	LastUsedAt *time.Time `gorm:"column:last_used_at" json:"last_used_at,omitempty"`
+	RevokedAt  *time.Time `gorm:"column:revoked_at" json:"revoked_at,omitempty"`
+	CreatedAt  time.Time  `gorm:"column:created_at" json:"created_at"`
+	UpdatedAt  time.Time  `gorm:"column:updated_at" json:"updated_at"`
+}
+
+func (APIKey) TableName() string { return "api_keys" }
+
+// APIRequestLog is one row per external API request (audit trail). The key value is never
+// recorded here.
+type APIRequestLog struct {
+	ID               uint64    `gorm:"primaryKey;column:id" json:"id"`
+	ClientID         *uint64   `gorm:"column:client_id" json:"client_id,omitempty"`
+	APIKeyID         *uint64   `gorm:"column:api_key_id" json:"api_key_id,omitempty"`
+	Method           string    `gorm:"column:method" json:"method"`
+	Endpoint         string    `gorm:"column:endpoint" json:"endpoint"`
+	RequestedUserIDs *string   `gorm:"column:requested_user_ids" json:"requested_user_ids,omitempty"`
+	YearFrom         *uint16   `gorm:"column:year_from" json:"year_from,omitempty"`
+	YearTo           *uint16   `gorm:"column:year_to" json:"year_to,omitempty"`
+	HTTPStatus       uint16    `gorm:"column:http_status" json:"http_status"`
+	IP               *string   `gorm:"column:ip" json:"ip,omitempty"`
+	LatencyMs        *uint32   `gorm:"column:latency_ms" json:"latency_ms,omitempty"`
+	CreatedAt        time.Time `gorm:"column:created_at" json:"created_at"`
+}
+
+func (APIRequestLog) TableName() string { return "api_request_logs" }

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -585,6 +585,19 @@ func SetupRoutes(router *gin.Engine) {
 					accessControl.GET("/users/:id/effective", middleware.RequirePermission("access.view", "ui.page.admin.access_control.view"), controllers.AdminGetUserEffectivePermissions)
 				}
 
+				// External API client & key management (guarded by api.clients.manage)
+				apiClients := admin.Group("/api-clients")
+				apiClients.Use(middleware.RequirePermission("api.clients.manage"))
+				{
+					apiClients.GET("", controllers.AdminListAPIClients)
+					apiClients.POST("", controllers.AdminCreateAPIClient)
+					apiClients.GET("/:id", controllers.AdminGetAPIClient)
+					apiClients.PATCH("/:id", controllers.AdminUpdateAPIClient)
+					apiClients.POST("/:id/keys", controllers.AdminIssueAPIKey)
+					apiClients.DELETE("/:id/keys/:keyId", controllers.AdminRevokeAPIKey)
+					apiClients.GET("/:id/logs", controllers.AdminListAPIClientLogs)
+				}
+
 				// Dashboard
 				admin.GET("/dashboard/stats", controllers.GetDashboardStats)
 				admin.GET("/submissions", controllers.GetAdminSubmissions) // Admin ดู submissions ทั้งหมด
@@ -885,6 +898,21 @@ func SetupRoutes(router *gin.Engine) {
 			staff.GET("/funds/structure", controllers.GetFundStructure)
 
 		}
+	}
+
+	// External / partner API group (/api/ext/v1).
+	// Authenticated by API key (not the internal JWT), so it hangs off `router` directly and
+	// does NOT inherit AuthMiddleware. Middleware order: log everything -> optional HTTPS guard
+	// -> API-key auth -> per-client rate limit -> per-route scope check -> handler.
+	ext := router.Group("/api/ext/v1")
+	ext.Use(middleware.ExtRequestLog())
+	ext.Use(middleware.RequireHTTPS())
+	ext.Use(middleware.APIKeyAuthMiddleware())
+	ext.Use(middleware.ExtRateLimit())
+	{
+		ext.GET("/scopus/publications",
+			middleware.RequireScope("scopus.publications.read"),
+			controllers.ExtListScopusPublications)
 	}
 
 	// Catch-all route for 404

--- a/services/api_client_service.go
+++ b/services/api_client_service.go
@@ -1,0 +1,359 @@
+package services
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"strings"
+	"time"
+
+	"fund-management-api/config"
+	"fund-management-api/models"
+
+	"gorm.io/gorm"
+)
+
+// apiKeyRawPrefix is the human-visible marker on every raw key ("fund service key").
+const apiKeyRawPrefix = "fsk_"
+
+var (
+	// ErrAPIKeyInvalid is returned when a presented key does not resolve to an active,
+	// non-expired key belonging to an active client.
+	ErrAPIKeyInvalid = errors.New("invalid api key")
+	// ErrAPIClientNotFound is returned by management operations on a missing client.
+	ErrAPIClientNotFound = errors.New("api client not found")
+	// ErrAPIScopeNotFound is returned when an unknown scope code is granted to a client.
+	ErrAPIScopeNotFound = errors.New("api scope not found")
+)
+
+// APIClientService owns creation/verification of external API clients and keys and writes
+// the request audit log. It reuses the global config.DB like the other services.
+type APIClientService struct {
+	db *gorm.DB
+}
+
+// NewAPIClientService instantiates the service.
+func NewAPIClientService(db *gorm.DB) *APIClientService {
+	if db == nil {
+		db = config.DB
+	}
+	return &APIClientService{db: db}
+}
+
+// HashAPIKey returns the lowercase hex SHA-256 of a raw key. This is what we store and what
+// we look up by on each request — a direct hash lookup (not bcrypt) so verification is O(1).
+func HashAPIKey(raw string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(raw)))
+	return hex.EncodeToString(sum[:])
+}
+
+// GenerateAPIKey mints a new random raw key and returns (rawKey, prefix, hash). The raw key
+// is returned to the caller exactly once and never stored; only the hash is persisted.
+func GenerateAPIKey() (raw, prefix, hash string, err error) {
+	buf := make([]byte, 32) // 256 bits of entropy
+	if _, err = rand.Read(buf); err != nil {
+		return "", "", "", err
+	}
+	raw = apiKeyRawPrefix + base64.RawURLEncoding.EncodeToString(buf)
+	// key_prefix column is varchar(16); a 12-char prefix is enough to identify a key in listings.
+	prefix = raw
+	if len(prefix) > 12 {
+		prefix = prefix[:12]
+	}
+	return raw, prefix, HashAPIKey(raw), nil
+}
+
+// VerifiedAPIKey bundles the resolved client, its granted scope codes, and the key record
+// that authenticated the request.
+type VerifiedAPIKey struct {
+	Client *models.APIClient
+	Key    *models.APIKey
+	Scopes []string
+}
+
+// VerifyAPIKey resolves a raw key to its client + scopes, enforcing key status/expiry and
+// client status. On success it best-effort updates last_used_at. Returns ErrAPIKeyInvalid
+// for any failure so callers cannot distinguish "unknown" from "expired".
+func (s *APIClientService) VerifyAPIKey(raw string) (*VerifiedAPIKey, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, ErrAPIKeyInvalid
+	}
+
+	var key models.APIKey
+	if err := s.db.Where("key_hash = ? AND status = ?", HashAPIKey(raw), "active").First(&key).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrAPIKeyInvalid
+		}
+		return nil, err
+	}
+
+	if key.ExpiresAt != nil && key.ExpiresAt.Before(time.Now()) {
+		return nil, ErrAPIKeyInvalid
+	}
+
+	var client models.APIClient
+	if err := s.db.Where("id = ?", key.ClientID).First(&client).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrAPIKeyInvalid
+		}
+		return nil, err
+	}
+	if client.Status != "active" {
+		return nil, ErrAPIKeyInvalid
+	}
+
+	scopes, err := s.scopesForClient(client.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Best-effort: record last usage. A failure here must not block the request.
+	now := time.Now()
+	s.db.Model(&models.APIKey{}).Where("id = ?", key.ID).Update("last_used_at", now)
+
+	return &VerifiedAPIKey{Client: &client, Key: &key, Scopes: scopes}, nil
+}
+
+// scopesForClient returns the scope codes granted to a client.
+func (s *APIClientService) scopesForClient(clientID uint64) ([]string, error) {
+	var codes []string
+	err := s.db.Table("api_client_scopes AS acs").
+		Select("sc.code").
+		Joins("INNER JOIN api_scopes sc ON sc.id = acs.scope_id").
+		Where("acs.client_id = ?", clientID).
+		Pluck("sc.code", &codes).Error
+	return codes, err
+}
+
+// --- Management operations (admin) ---
+
+// CreateClient creates a client and grants the given scope codes atomically.
+func (s *APIClientService) CreateClient(name string, description, contactEmail *string, scopeCodes []string) (*models.APIClient, []string, error) {
+	client := &models.APIClient{
+		Name:         strings.TrimSpace(name),
+		Description:  description,
+		ContactEmail: contactEmail,
+		Status:       "active",
+	}
+
+	var granted []string
+	err := s.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(client).Error; err != nil {
+			return err
+		}
+		g, err := setClientScopes(tx, client.ID, scopeCodes)
+		if err != nil {
+			return err
+		}
+		granted = g
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return client, granted, nil
+}
+
+// setClientScopes replaces a client's scope grants with the given codes and returns the
+// codes actually granted. Unknown scope codes cause ErrAPIScopeNotFound.
+func setClientScopes(tx *gorm.DB, clientID uint64, scopeCodes []string) ([]string, error) {
+	if err := tx.Where("client_id = ?", clientID).Delete(&models.APIClientScope{}).Error; err != nil {
+		return nil, err
+	}
+
+	granted := make([]string, 0, len(scopeCodes))
+	seen := map[string]struct{}{}
+	for _, code := range scopeCodes {
+		code = strings.TrimSpace(code)
+		if code == "" {
+			continue
+		}
+		if _, dup := seen[code]; dup {
+			continue
+		}
+		seen[code] = struct{}{}
+
+		var scope models.APIScope
+		if err := tx.Where("code = ?", code).First(&scope).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil, ErrAPIScopeNotFound
+			}
+			return nil, err
+		}
+		if err := tx.Create(&models.APIClientScope{ClientID: clientID, ScopeID: scope.ID}).Error; err != nil {
+			return nil, err
+		}
+		granted = append(granted, code)
+	}
+	return granted, nil
+}
+
+// UpdateClient updates mutable client fields and (when scopeCodes is non-nil) replaces its
+// scope grants. A nil pointer field is left unchanged.
+func (s *APIClientService) UpdateClient(clientID uint64, name, description, contactEmail, status *string, scopeCodes []string) (*models.APIClient, []string, error) {
+	var client models.APIClient
+	if err := s.db.Where("id = ?", clientID).First(&client).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil, ErrAPIClientNotFound
+		}
+		return nil, nil, err
+	}
+
+	updates := map[string]interface{}{}
+	if name != nil {
+		updates["name"] = strings.TrimSpace(*name)
+	}
+	if description != nil {
+		updates["description"] = description
+	}
+	if contactEmail != nil {
+		updates["contact_email"] = contactEmail
+	}
+	if status != nil && (*status == "active" || *status == "disabled") {
+		updates["status"] = *status
+	}
+
+	granted, err := s.scopesForClient(client.ID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	err = s.db.Transaction(func(tx *gorm.DB) error {
+		if len(updates) > 0 {
+			if err := tx.Model(&models.APIClient{}).Where("id = ?", client.ID).Updates(updates).Error; err != nil {
+				return err
+			}
+		}
+		if scopeCodes != nil {
+			g, err := setClientScopes(tx, client.ID, scopeCodes)
+			if err != nil {
+				return err
+			}
+			granted = g
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if err := s.db.Where("id = ?", client.ID).First(&client).Error; err != nil {
+		return nil, nil, err
+	}
+	return &client, granted, nil
+}
+
+// ClientWithScopes is a client plus its granted scope codes, for listing.
+type ClientWithScopes struct {
+	models.APIClient
+	Scopes []string `json:"scopes"`
+}
+
+// ListClients returns all clients with their scope codes.
+func (s *APIClientService) ListClients() ([]ClientWithScopes, error) {
+	var clients []models.APIClient
+	if err := s.db.Order("created_at DESC").Find(&clients).Error; err != nil {
+		return nil, err
+	}
+	out := make([]ClientWithScopes, 0, len(clients))
+	for _, c := range clients {
+		scopes, err := s.scopesForClient(c.ID)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, ClientWithScopes{APIClient: c, Scopes: scopes})
+	}
+	return out, nil
+}
+
+// GetClient returns one client with its scopes.
+func (s *APIClientService) GetClient(clientID uint64) (*ClientWithScopes, error) {
+	var client models.APIClient
+	if err := s.db.Where("id = ?", clientID).First(&client).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrAPIClientNotFound
+		}
+		return nil, err
+	}
+	scopes, err := s.scopesForClient(client.ID)
+	if err != nil {
+		return nil, err
+	}
+	return &ClientWithScopes{APIClient: client, Scopes: scopes}, nil
+}
+
+// ListKeys returns the (non-secret) key records for a client.
+func (s *APIClientService) ListKeys(clientID uint64) ([]models.APIKey, error) {
+	var keys []models.APIKey
+	err := s.db.Where("client_id = ?", clientID).Order("created_at DESC").Find(&keys).Error
+	return keys, err
+}
+
+// IssuedKey is the one-time result of issuing a key: the plaintext value plus its record.
+type IssuedKey struct {
+	RawKey string        `json:"raw_key"`
+	Key    models.APIKey `json:"key"`
+}
+
+// IssueKey mints a new key for a client and returns the raw value ONCE. Only the hash is stored.
+func (s *APIClientService) IssueKey(clientID uint64, label *string, expiresAt *time.Time) (*IssuedKey, error) {
+	var client models.APIClient
+	if err := s.db.Where("id = ?", clientID).First(&client).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrAPIClientNotFound
+		}
+		return nil, err
+	}
+
+	raw, prefix, hash, err := GenerateAPIKey()
+	if err != nil {
+		return nil, err
+	}
+
+	key := models.APIKey{
+		ClientID:  clientID,
+		Label:     label,
+		KeyPrefix: prefix,
+		KeyHash:   hash,
+		Status:    "active",
+		ExpiresAt: expiresAt,
+	}
+	if err := s.db.Create(&key).Error; err != nil {
+		return nil, err
+	}
+	return &IssuedKey{RawKey: raw, Key: key}, nil
+}
+
+// RevokeKey marks a key revoked. It is idempotent and scoped to the owning client.
+func (s *APIClientService) RevokeKey(clientID, keyID uint64) error {
+	now := time.Now()
+	res := s.db.Model(&models.APIKey{}).
+		Where("id = ? AND client_id = ?", keyID, clientID).
+		Updates(map[string]interface{}{"status": "revoked", "revoked_at": now})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrAPIClientNotFound
+	}
+	return nil
+}
+
+// ListRequestLogs returns recent audit log rows for a client (newest first).
+func (s *APIClientService) ListRequestLogs(clientID uint64, limit int) ([]models.APIRequestLog, error) {
+	if limit <= 0 || limit > 500 {
+		limit = 100
+	}
+	var logs []models.APIRequestLog
+	err := s.db.Where("client_id = ?", clientID).Order("created_at DESC").Limit(limit).Find(&logs).Error
+	return logs, err
+}
+
+// WriteRequestLog appends one audit row. Errors are swallowed by the caller (best effort);
+// this method returns the error so tests can assert on it.
+func (s *APIClientService) WriteRequestLog(entry *models.APIRequestLog) error {
+	return s.db.Create(entry).Error
+}

--- a/services/scopus_publication_service.go
+++ b/services/scopus_publication_service.go
@@ -71,6 +71,22 @@ type ScopusPublicationByUser struct {
 	DocumentID             uint       `json:"document_id"`
 	Title                  string     `json:"title"`
 	PublicationName        *string    `json:"publication_name,omitempty"`
+	Abstract               *string    `json:"abstract,omitempty"`
+	AggregationType        *string    `json:"aggregation_type,omitempty"`
+	Subtype                *string    `json:"subtype,omitempty"`
+	SubtypeDescription     *string    `json:"subtype_description,omitempty"`
+	ISSN                   *string    `json:"issn,omitempty"`
+	EISSN                  *string    `json:"eissn,omitempty"`
+	ISBN                   *string    `json:"isbn,omitempty"`
+	Volume                 *string    `json:"volume,omitempty"`
+	Issue                  *string    `json:"issue,omitempty"`
+	PageRange              *string    `json:"page_range,omitempty"`
+	ArticleNumber          *string    `json:"article_number,omitempty"`
+	AuthKeywords           *string    `json:"authkeywords,omitempty"`
+	FundAcr                *string    `json:"fund_acr,omitempty"`
+	FundSponsor            *string    `json:"fund_sponsor,omitempty"`
+	OpenAccess             *int       `json:"openaccess,omitempty"`
+	OpenAccessFlag         *int       `json:"openaccess_flag,omitempty"`
 	AffiliationAFID        *string    `json:"affiliation_afid,omitempty"`
 	AffiliationName        *string    `json:"affiliation_name,omitempty"`
 	AffiliationCity        *string    `json:"affiliation_city,omitempty"`
@@ -170,6 +186,22 @@ type scopusPublicationByUserRow struct {
 	DocumentID             uint    `gorm:"column:document_id"`
 	Title                  *string
 	PublicationName        *string
+	Abstract               *string
+	AggregationType        *string
+	Subtype                *string
+	SubtypeDescription     *string `gorm:"column:subtype_description"`
+	ISSN                   *string
+	EISSN                  *string
+	ISBN                   *string
+	Volume                 *string
+	Issue                  *string
+	PageRange              *string
+	ArticleNumber          *string
+	AuthKeywords           []byte  `gorm:"column:authkeywords"`
+	FundAcr                *string `gorm:"column:fund_acr"`
+	FundSponsor            *string `gorm:"column:fund_sponsor"`
+	OpenAccess             *int    `gorm:"column:openaccess"`
+	OpenAccessFlag         *int    `gorm:"column:openaccess_flag"`
 	UserAffiliationAFID    *string `gorm:"column:user_affiliation_afid"`
 	UserAffiliationName    *string `gorm:"column:user_affiliation_name"`
 	UserAffiliationCity    *string `gorm:"column:user_affiliation_city"`
@@ -493,7 +525,7 @@ func (s *ScopusPublicationService) ListForPartner(userIDs []uint, yearFrom, year
 
 	metricYearExpr := metricYearForDocumentExpression(s.db)
 	base := s.db.Table("(?) AS pairs", pairQuery).
-		Select("pairs.user_id, TRIM(CONCAT(COALESCE(u.user_fname,''), ' ', COALESCE(u.user_lname,''))) AS user_name, u.email AS user_email, u.Scopus_id AS user_scopus_id, sd.id AS document_id, sd.title, sd.publication_name, owner_aff.afid AS user_affiliation_afid, owner_aff.name AS user_affiliation_name, owner_aff.city AS user_affiliation_city, owner_aff.country AS user_affiliation_country, owner_aff.affiliation_url AS user_affiliation_url, sd.source_id, sd.cover_date, sd.cover_display_date, sd.citedby_count, sd.doi, sd.eid, sd.scopus_id, sd.scopus_link, sd.conference_name, sd.conference_venue, sd.conference_city, sd.conference_country, sd.conference_location, metrics.cite_score_percentile, metrics.cite_score_quartile, metrics.cite_score_status, metrics.cite_score_rank").
+		Select("pairs.user_id, TRIM(CONCAT(COALESCE(u.user_fname,''), ' ', COALESCE(u.user_lname,''))) AS user_name, u.email AS user_email, u.Scopus_id AS user_scopus_id, sd.id AS document_id, sd.title, sd.publication_name, sd.abstract, sd.aggregation_type, sd.subtype, sd.subtype_description, sd.issn, sd.eissn, sd.isbn, sd.volume, sd.issue, sd.page_range, sd.article_number, sd.authkeywords, sd.fund_acr, sd.fund_sponsor, sd.openaccess, sd.openaccess_flag, owner_aff.afid AS user_affiliation_afid, owner_aff.name AS user_affiliation_name, owner_aff.city AS user_affiliation_city, owner_aff.country AS user_affiliation_country, owner_aff.affiliation_url AS user_affiliation_url, sd.source_id, sd.cover_date, sd.cover_display_date, sd.citedby_count, sd.doi, sd.eid, sd.scopus_id, sd.scopus_link, sd.conference_name, sd.conference_venue, sd.conference_city, sd.conference_country, sd.conference_location, metrics.cite_score_percentile, metrics.cite_score_quartile, metrics.cite_score_status, metrics.cite_score_rank").
 		Joins("INNER JOIN users u ON u.user_id = pairs.user_id").
 		Joins("INNER JOIN scopus_documents sd ON sd.id = pairs.document_id").
 		Joins("LEFT JOIN scopus_affiliations AS owner_aff ON owner_aff.id = pairs.user_affiliation_id").
@@ -645,6 +677,29 @@ func mapScopusRowsByUser(rows []scopusPublicationByUserRow, affiliationByDocumen
 			CiteScoreQuartile:      normalizeNullable(row.CiteScoreQuartile),
 			CiteScoreStatus:        normalizeNullable(row.CiteScoreStatus),
 			CiteScoreRank:          row.CiteScoreRank,
+		}
+
+		// Bibliographic fields (populated only when the caller SELECTs them, e.g. the
+		// partner endpoint; nil/omitted for the internal dashboard which does not).
+		pub.Abstract = normalizeNullable(row.Abstract)
+		pub.AggregationType = normalizeNullable(row.AggregationType)
+		pub.Subtype = normalizeNullable(row.Subtype)
+		pub.SubtypeDescription = normalizeNullable(row.SubtypeDescription)
+		pub.ISSN = normalizeNullable(row.ISSN)
+		pub.EISSN = normalizeNullable(row.EISSN)
+		pub.ISBN = normalizeNullable(row.ISBN)
+		pub.Volume = normalizeNullable(row.Volume)
+		pub.Issue = normalizeNullable(row.Issue)
+		pub.PageRange = normalizeNullable(row.PageRange)
+		pub.ArticleNumber = normalizeNullable(row.ArticleNumber)
+		pub.FundAcr = normalizeNullable(row.FundAcr)
+		pub.FundSponsor = normalizeNullable(row.FundSponsor)
+		pub.OpenAccess = row.OpenAccess
+		pub.OpenAccessFlag = row.OpenAccessFlag
+		if len(row.AuthKeywords) > 0 {
+			if kw := strings.TrimSpace(string(row.AuthKeywords)); kw != "" {
+				pub.AuthKeywords = &kw
+			}
 		}
 
 		if affiliation, ok := affiliationByDocument[row.DocumentID]; ok {

--- a/services/scopus_publication_service.go
+++ b/services/scopus_publication_service.go
@@ -453,6 +453,72 @@ func (s *ScopusPublicationService) ListByUserOwnership(limit, offset int, sortFi
 	return mapScopusRowsByUser(rows, affiliationByDocument, authorsByDocument), total, nil
 }
 
+// ListForPartner returns paginated Scopus publications for a fixed set of users, filtered by
+// a cover-year range. It powers the external /api/ext partner API. It reuses the exact
+// (user, document) join core used by ListByUserOwnership, adding a `user_id IN (...)` filter
+// and an inclusive year-range bound. userIDs must be non-empty; yearFrom/yearTo are inclusive.
+func (s *ScopusPublicationService) ListForPartner(userIDs []uint, yearFrom, yearTo, limit, offset int) ([]ScopusPublicationByUser, int64, error) {
+	if len(userIDs) == 0 {
+		return []ScopusPublicationByUser{}, 0, nil
+	}
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 500 {
+		limit = 500
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	yearExpr := yearExpression(s.db)
+
+	pairQuery := s.db.Table("users AS u").
+		Select("u.user_id, sd.id AS document_id, MIN(sda.affiliation_id) AS user_affiliation_id").
+		Joins("INNER JOIN scopus_authors sa ON sa.scopus_author_id = u.Scopus_id").
+		Joins("INNER JOIN scopus_document_authors sda ON sda.author_id = sa.id").
+		Joins("INNER JOIN scopus_documents sd ON sd.id = sda.document_id").
+		Where("u.Scopus_id IS NOT NULL AND TRIM(u.Scopus_id) <> ''").
+		Where("u.user_id IN ?", userIDs).
+		Where(fmt.Sprintf("%s >= ? AND %s <= ?", yearExpr, yearExpr), yearFrom, yearTo).
+		Group("u.user_id, sd.id")
+
+	var total int64
+	if err := s.db.Table("(?) AS user_doc_pairs", pairQuery).Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	if total == 0 {
+		return []ScopusPublicationByUser{}, 0, nil
+	}
+
+	metricYearExpr := metricYearForDocumentExpression(s.db)
+	base := s.db.Table("(?) AS pairs", pairQuery).
+		Select("pairs.user_id, TRIM(CONCAT(COALESCE(u.user_fname,''), ' ', COALESCE(u.user_lname,''))) AS user_name, u.email AS user_email, u.Scopus_id AS user_scopus_id, sd.id AS document_id, sd.title, sd.publication_name, owner_aff.afid AS user_affiliation_afid, owner_aff.name AS user_affiliation_name, owner_aff.city AS user_affiliation_city, owner_aff.country AS user_affiliation_country, owner_aff.affiliation_url AS user_affiliation_url, sd.source_id, sd.cover_date, sd.cover_display_date, sd.citedby_count, sd.doi, sd.eid, sd.scopus_id, sd.scopus_link, sd.conference_name, sd.conference_venue, sd.conference_city, sd.conference_country, sd.conference_location, metrics.cite_score_percentile, metrics.cite_score_quartile, metrics.cite_score_status, metrics.cite_score_rank").
+		Joins("INNER JOIN users u ON u.user_id = pairs.user_id").
+		Joins("INNER JOIN scopus_documents sd ON sd.id = pairs.document_id").
+		Joins("LEFT JOIN scopus_affiliations AS owner_aff ON owner_aff.id = pairs.user_affiliation_id").
+		Joins("LEFT JOIN scopus_source_metrics AS metrics ON metrics.source_id = sd.source_id AND metrics.doc_type = 'all' AND metrics.metric_year = " + metricYearExpr)
+
+	orderClause := orderForScopusByUser("year", "desc")
+	var rows []scopusPublicationByUserRow
+	if err := base.Order(orderClause).Limit(limit).Offset(offset).Find(&rows).Error; err != nil {
+		return nil, 0, err
+	}
+
+	documentIDs := collectDocumentIDsByUser(rows)
+	affiliationByDocument, err := s.loadDocumentAffiliationAggregates(documentIDs)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	authorsByDocument, err := s.loadDocumentAuthorAggregates(documentIDs)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return mapScopusRowsByUser(rows, affiliationByDocument, authorsByDocument), total, nil
+}
+
 func mapScopusRows(rows []scopusPublicationRow, affiliationByDocument map[uint]scopusAffiliationAggregate, authorsByDocument map[uint]*string) []ScopusPublication {
 	publications := make([]ScopusPublication, 0, len(rows))
 	for _, row := range rows {

--- a/services/scopus_publication_service_test.go
+++ b/services/scopus_publication_service_test.go
@@ -292,3 +292,46 @@ func TestListByUserOwnershipBuildsCompleteSubqueries(t *testing.T) {
 		t.Fatalf("unmet expectations: %v", err)
 	}
 }
+
+func TestListForPartnerBuildsCompleteSubqueries(t *testing.T) {
+	// Same derived-table structure as ListByUserOwnership, plus a `u.user_id IN (...)`
+	// filter in the inner pairs subquery (the year-range filter is dialect-specific, so we
+	// don't pin it here).
+	countPattern := regexp.MustCompile(`(?is)SELECT count\(\*\) FROM \(SELECT u\.user_id, sd\.id AS document_id.*scopus_document_authors.*u\.user_id IN.*GROUP BY u\.user_id, sd\.id\) AS user_doc_pairs`)
+	listPattern := regexp.MustCompile(`(?is)SELECT pairs\.user_id.*FROM \(SELECT u\.user_id, sd\.id AS document_id.*u\.user_id IN.*GROUP BY u\.user_id, sd\.id\) AS pairs.*LIMIT \?`)
+
+	steps := []*queryStep{
+		{
+			kind:    kindQuery,
+			pattern: countPattern,
+			args:    []driver.Value{int64(1), int64(2), int64(2020), int64(2024)},
+			columns: []string{"count"},
+			rows:    [][]driver.Value{{int64(2)}},
+		},
+		{
+			kind:    kindQuery,
+			pattern: listPattern,
+			args:    []driver.Value{int64(1), int64(2), int64(2020), int64(2024), int64(50)},
+			columns: []string{"user_id", "document_id"},
+			rows:    [][]driver.Value{},
+		},
+	}
+
+	db, state, cleanup := newScriptedGormDB(t, steps)
+	defer cleanup()
+
+	items, total, err := NewScopusPublicationService(db).
+		ListForPartner([]uint{1, 2}, 2020, 2024, 50, 0)
+	if err != nil {
+		t.Fatalf("ListForPartner returned error: %v", err)
+	}
+	if total != 2 {
+		t.Fatalf("expected total 2, got %d", total)
+	}
+	if len(items) != 0 {
+		t.Fatalf("expected no mapped rows from the empty result set, got %d", len(items))
+	}
+	if err := state.verifyComplete(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
Adds a reusable external/partner API subsystem and its first endpoint.

- `/api/ext/v1` group authenticated by DB-stored API keys (SHA-256 hash, `Authorization: Bearer`), authorized by scope, with per-request audit logging + per-client in-memory rate limiting.
- `GET /api/ext/v1/scopus/publications` — flat, paginated, filtered by `user_ids` + inclusive cover-year range; returns full bibliographic fields. Reuses the existing Scopus join via new `ScopusPublicationService.ListForPartner` (internal dashboard untouched).
- Admin CRUD under `/api/v1/admin/api-clients` (gated by `api.clients.manage`).
- Migration `035` (api_clients, api_scopes, api_client_scopes, api_keys, api_request_logs).
- Docs: consumer guide + internal operator guide.

## Verified
- `go build ./...`, `go vet`, `go test ./services/` pass.
- Live-tested on the intern DB over HTTP: 200 with data, 401/403/422/429 cases, audit log + last_used_at written.

## Notes
- Designed to host future external APIs (e.g. a users/directory sync endpoint).
- Not yet deployed: migration 035 still needs to run on prod; enforce HTTPS at the proxy.