### PR TITLE
feat: external faculty (users) directory API for sync

### DIFF
--- a/controllers/ext_users_controller.go
+++ b/controllers/ext_users_controller.go
@@ -1,0 +1,67 @@
+package controllers
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"fund-management-api/services"
+
+	"github.com/gin-gonic/gin"
+)
+
+// ExtListUsers is the external (partner) faculty-directory endpoint:
+//
+//	GET /api/ext/v1/users?updated_since=2026-01-01T00:00:00Z&limit=100&offset=0
+//
+// It returns a flat, paginated list of all faculty (excluding soft-deleted). `updated_since`
+// (RFC 3339) enables incremental sync; when omitted the full directory is returned. The
+// consumer is expected to pull periodically and store the result in its own database.
+func ExtListUsers(c *gin.Context) {
+	var updatedSince *time.Time
+	if raw := strings.TrimSpace(c.Query("updated_since")); raw != "" {
+		t, err := time.Parse(time.RFC3339, raw)
+		if err != nil {
+			extValidationError(c, "updated_since must be an RFC 3339 datetime, e.g. 2026-01-01T00:00:00Z")
+			return
+		}
+		updatedSince = &t
+	}
+
+	limit := parseIntOrDefault(c.Query("limit"), 100)
+	if limit <= 0 {
+		limit = 100
+	}
+	if limit > 500 {
+		limit = 500
+	}
+	offset := parseIntOrDefault(c.Query("offset"), 0)
+	if offset < 0 {
+		offset = 0
+	}
+
+	svc := services.NewUserDirectoryService(nil)
+	items, total, err := svc.ListForPartner(updatedSince, limit, offset)
+	if err != nil {
+		InternalError(c, "ext_users", err)
+		return
+	}
+
+	var updatedSinceOut interface{}
+	if updatedSince != nil {
+		updatedSinceOut = updatedSince.Format(time.RFC3339)
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"data":    items,
+		"paging": gin.H{
+			"total":  total,
+			"limit":  limit,
+			"offset": offset,
+		},
+		"filters": gin.H{
+			"updated_since": updatedSinceOut,
+		},
+	})
+}

--- a/docs/EXTERNAL_API_SCOPUS_INTERNAL.md
+++ b/docs/EXTERNAL_API_SCOPUS_INTERNAL.md
@@ -15,6 +15,21 @@ guide.
   join as the internal dashboard, adding a `user_id IN (...)` and inclusive cover-year filter.
   Existing service methods are untouched.
 
+## Endpoints & scopes
+
+| Endpoint | Scope | Consumer doc | Notes |
+|---|---|---|---|
+| `GET /api/ext/v1/scopus/publications` | `scopus.publications.read` | `EXTERNAL_API_SCOPUS.md` | seeded by migration 035 |
+| `GET /api/ext/v1/users` | `users.read` | `EXTERNAL_USERS_API.md` | seeded by migration 036; faculty directory sync |
+
+**Adding an external API = new endpoint + a new scope row (seed migration), reusing the
+api_clients/api_keys/middleware here — no new tables.**
+
+⚠️ **PII:** the `/users` endpoint returns `email` and `tel` (personal contact data). Grant
+`users.read` only to clients authorized to receive it, and record that in the client's contact
+notes. The faculty directory (`ListForPartner` in `services/user_directory_service.go`) excludes
+soft-deleted users (`delete_at IS NULL`) and never returns passwords.
+
 ## Database schema (migration `035_20260809_create_api_client_tables.sql`)
 
 | Table               | Purpose |

--- a/docs/EXTERNAL_USERS_API.md
+++ b/docs/EXTERNAL_USERS_API.md
@@ -1,0 +1,183 @@
+# External API — Faculty Directory (Consumer Guide)
+
+REST API for pulling the faculty (users) directory from the Fund Management platform so an
+external system can keep a synced copy. This guide is for the **calling system's developers**.
+
+> Intended use: **periodic master-data sync**, not per-request lookups. Pull on a schedule
+> (e.g. a nightly/hourly cron), store the result in your own database, and have your app read
+> from that local copy. Do **not** call this API on every page load.
+
+## Base URL
+
+```
+https://<host>/api/ext/v1
+```
+
+Versioned; breaking changes ship under a new version (`/api/ext/v2`).
+
+## Authentication
+
+Send your API key as a Bearer token on every request:
+
+```
+Authorization: Bearer <your-api-key>
+```
+
+- The key looks like `fsk_XXXXXXXXXXXXXXXXXXXXXX`. Keep it secret (backend only — never in
+  front-end code, URLs, or logs).
+- Call server-to-server from your backend; your own site does **not** need a registered domain
+  or HTTPS to consume this API. (Our endpoint should be HTTPS in production so the key is not
+  exposed in transit.)
+
+## Endpoint: List faculty
+
+```
+GET /api/ext/v1/users
+```
+
+Returns a **flat, paginated** list of faculty. Soft-deleted (removed) users are excluded. Each
+record's stable key is `user_id`.
+
+### Query parameters
+
+| Param           | Required | Description |
+|-----------------|----------|-------------|
+| `updated_since` | ❌       | RFC 3339 datetime. Returns only users modified at/after this time (incremental sync). Omit for a full pull. |
+| `limit`         | ❌       | Page size. Default `100`, max `500`. |
+| `offset`        | ❌       | Rows to skip. Default `0`. |
+
+### Sync strategy (recommended)
+
+1. **First run:** full pull — call without `updated_since`, paging with `limit`/`offset` until
+   you have everyone.
+2. **Subsequent runs:** incremental — pass `updated_since` = the max `updated_at` you have
+   stored, to fetch only what changed.
+3. **Periodic reconcile:** incremental sync cannot detect deletions. Do a **full pull on a
+   slower cadence** (e.g. weekly) and remove/deactivate on your side any `user_id` not present.
+4. Use `is_active` to decide who is currently active — we return all non-deleted users and let
+   you filter.
+
+### Example request
+
+```bash
+curl -H "Authorization: Bearer fsk_XXXXXXXXXXXX" \
+  "https://<host>/api/ext/v1/users?updated_since=2026-01-01T00:00:00Z&limit=100&offset=0"
+```
+
+### Example response `200 OK`
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "user_id": 1001,
+      "prefix": "ผศ.ดร.",
+      "user_fname": "งามนิจ",
+      "user_lname": "อาจอินทร์",
+      "gender": "female",
+      "email": "ngamnij@kku.ac.th",
+      "tel": "043000000",
+      "tel_format": "0-4300-0000",
+      "position_title": "ผู้ช่วยศาสตราจารย์",
+      "position_en": "Assistant Professor",
+      "prefix_position_en": "Asst. Prof.",
+      "manage_position": "รองหัวหน้าภาควิชา",
+      "name_en": "Ngamnij Arch-int",
+      "suffix_en": "Ph.D.",
+      "scopus_id": "6506313280",
+      "scholar_author_id": "xxxxxxx",
+      "lab_name": "Data Engineering Lab",
+      "room": "IT-401",
+      "cp_web_id": "12345",
+      "role_id": 1,
+      "role_name": "teacher",
+      "is_active": "1",
+      "updated_at": "2026-07-01T09:30:00+07:00"
+    }
+  ],
+  "paging": { "total": 320, "limit": 100, "offset": 0 },
+  "filters": { "updated_since": "2026-01-01T00:00:00Z" }
+}
+```
+
+Nullable fields are **omitted** when empty — don't assume every field is present.
+
+### Response field reference
+
+| Field | Type | Nullable | Meaning |
+|-------|------|----------|---------|
+| `user_id` | integer | no | Stable primary key. Use as your sync key. Same id used by the Scopus endpoint. |
+| `prefix` | string | yes | Thai name prefix (คำนำหน้า). |
+| `user_fname` / `user_lname` | string | no | First / last name (Thai). |
+| `gender` | string | yes | Gender. |
+| `email` | string | yes | Email. **Personal data** — handle per your agreement. |
+| `tel` | string | yes | Phone number. **Personal data.** |
+| `tel_format` | string | yes | Formatted phone number. |
+| `position_title` | string | yes | Academic position (Thai), e.g. `ผู้ช่วยศาสตราจารย์`. |
+| `position_en` | string | yes | Academic position (English). |
+| `prefix_position_en` | string | yes | Position prefix (English), e.g. `Asst. Prof.`. |
+| `manage_position` | string | yes | Management/administrative position (Thai), if any. |
+| `name_en` | string | yes | Full name (English). |
+| `suffix_en` | string | yes | Name suffix (English), e.g. `Ph.D.`. |
+| `scopus_id` | string | yes | Scopus Author ID (use with the Scopus publications endpoint). |
+| `scholar_author_id` | string | yes | Google Scholar author id. |
+| `lab_name` | string | yes | Lab name. |
+| `room` | string | yes | Office/room. |
+| `cp_web_id` | string | yes | Internal CP web id. |
+| `role_id` | integer | no | Role id in our system. |
+| `role_name` | string | yes | Role name, e.g. `teacher`, `staff`, `admin`, `dept_head`, `executive`. |
+| `is_active` | string | yes | Account active flag (`"1"`/`"0"`). Filter active users on your side. |
+| `updated_at` | datetime (RFC 3339) | yes | Last modification time. Store the max value to drive `updated_since` next run. |
+
+### Suggested storage on your side (optional — adapt freely)
+
+One row per faculty, keyed on `user_id`, upserted on each sync:
+
+```sql
+CREATE TABLE faculty (
+  user_id           INT           NOT NULL,
+  prefix            VARCHAR(50),
+  user_fname        VARCHAR(255)  NOT NULL,
+  user_lname        VARCHAR(255)  NOT NULL,
+  email             VARCHAR(255),
+  position_title    VARCHAR(255),
+  position_en       VARCHAR(255),
+  name_en           VARCHAR(255),
+  scopus_id         VARCHAR(64),
+  role_id           INT,
+  role_name         VARCHAR(64),
+  is_active         TINYINT(1),
+  source_updated_at DATETIME,          -- = updated_at from the API
+  synced_at         DATETIME NOT NULL, -- when you fetched it
+  raw_json          JSON,              -- optional: keep the whole record
+  PRIMARY KEY (user_id)
+);
+```
+
+Keep only the columns you need; stash the rest in `raw_json`. On each sync, `UPSERT` on
+`user_id` and track `MAX(source_updated_at)` for the next `updated_since`.
+
+### Error format
+
+```json
+{ "success": false, "error": "<message>", "code": "<CODE>" }
+```
+
+| HTTP | `code`                 | Meaning |
+|------|------------------------|---------|
+| 401  | `MISSING_API_KEY`      | No `Authorization: Bearer` header. |
+| 401  | `INVALID_API_KEY`      | Key unknown, revoked, or expired. |
+| 403  | `INSUFFICIENT_SCOPE`   | Key lacks the `users.read` scope. |
+| 422  | `INVALID_PARAMETER`    | Invalid `updated_since` (must be RFC 3339). |
+| 429  | `RATE_LIMIT_EXCEEDED`  | Too many requests. Respect the `Retry-After` header (seconds). |
+| 500  | —                      | Internal error. |
+
+### Pagination
+
+Use `paging.total` to iterate: increase `offset` by `limit` until `offset >= total`.
+
+### Rate limiting
+
+Each client has a fixed request budget per minute (default **100**). A scheduled batch sync
+should stay well under this — page steadily, don't burst.

--- a/migrations/036_20260812_add_users_read_scope.sql
+++ b/migrations/036_20260812_add_users_read_scope.sql
@@ -1,0 +1,6 @@
+-- External API: add the `users.read` scope for the faculty (users) directory endpoint.
+-- Reuses the api_* subsystem from migration 035; no new tables.
+
+INSERT INTO api_scopes (code, description)
+VALUES ('users.read', 'Read faculty (users) directory via the external API')
+ON DUPLICATE KEY UPDATE description = VALUES(description);

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -913,6 +913,10 @@ func SetupRoutes(router *gin.Engine) {
 		ext.GET("/scopus/publications",
 			middleware.RequireScope("scopus.publications.read"),
 			controllers.ExtListScopusPublications)
+
+		ext.GET("/users",
+			middleware.RequireScope("users.read"),
+			controllers.ExtListUsers)
 	}
 
 	// Catch-all route for 404

--- a/services/user_directory_service.go
+++ b/services/user_directory_service.go
@@ -1,0 +1,109 @@
+package services
+
+import (
+	"time"
+
+	"fund-management-api/config"
+
+	"gorm.io/gorm"
+)
+
+// PartnerUser is one faculty (users) record exposed to external clients via /api/ext.
+// Column tags map the mixed-case DB columns to clean snake_case JSON keys. Nullable fields
+// are pointers with omitempty; user_id / names / role_id are always present.
+type PartnerUser struct {
+	UserID           int        `gorm:"column:user_id" json:"user_id"`
+	Prefix           *string    `gorm:"column:prefix" json:"prefix,omitempty"`
+	UserFname        string     `gorm:"column:user_fname" json:"user_fname"`
+	UserLname        string     `gorm:"column:user_lname" json:"user_lname"`
+	Gender           *string    `gorm:"column:gender" json:"gender,omitempty"`
+	Email            *string    `gorm:"column:email" json:"email,omitempty"`
+	Tel              *string    `gorm:"column:tel" json:"tel,omitempty"`
+	TelFormat        *string    `gorm:"column:tel_format" json:"tel_format,omitempty"`
+	PositionTitle    *string    `gorm:"column:position_title" json:"position_title,omitempty"`
+	PositionEn       *string    `gorm:"column:position_en" json:"position_en,omitempty"`
+	PrefixPositionEn *string    `gorm:"column:prefix_position_en" json:"prefix_position_en,omitempty"`
+	ManagePosition   *string    `gorm:"column:manage_position" json:"manage_position,omitempty"`
+	NameEn           *string    `gorm:"column:name_en" json:"name_en,omitempty"`
+	SuffixEn         *string    `gorm:"column:suffix_en" json:"suffix_en,omitempty"`
+	ScopusID         *string    `gorm:"column:scopus_id" json:"scopus_id,omitempty"`
+	ScholarAuthorID  *string    `gorm:"column:scholar_author_id" json:"scholar_author_id,omitempty"`
+	LabName          *string    `gorm:"column:lab_name" json:"lab_name,omitempty"`
+	Room             *string    `gorm:"column:room" json:"room,omitempty"`
+	CPWebID          *string    `gorm:"column:cp_web_id" json:"cp_web_id,omitempty"`
+	RoleID           int        `gorm:"column:role_id" json:"role_id"`
+	RoleName         *string    `gorm:"column:role_name" json:"role_name,omitempty"`
+	IsActive         *string    `gorm:"column:is_active" json:"is_active,omitempty"`
+	UpdatedAt        *time.Time `gorm:"column:updated_at" json:"updated_at,omitempty"`
+}
+
+// partnerUserSelect lists the columns (aliased to the JSON-friendly names above) fetched for
+// each user. The mixed-case source columns (TEL, Name_en, Scopus_id, ...) are aliased here so
+// the scan mapping stays unambiguous.
+const partnerUserSelect = "u.user_id AS user_id, u.prefix AS prefix, u.user_fname AS user_fname, " +
+	"u.user_lname AS user_lname, u.gender AS gender, u.email AS email, u.TEL AS tel, " +
+	"u.TELformat AS tel_format, u.position AS position_title, u.position_en AS position_en, " +
+	"u.prefix_position_en AS prefix_position_en, u.manage_position AS manage_position, " +
+	"u.Name_en AS name_en, u.suffix_en AS suffix_en, u.Scopus_id AS scopus_id, " +
+	"u.scholar_author_id AS scholar_author_id, u.LAB_Name AS lab_name, u.Room AS room, " +
+	"u.CP_WEB_ID AS cp_web_id, u.role_id AS role_id, r.role AS role_name, " +
+	"u.Is_active AS is_active, u.update_at AS updated_at"
+
+// UserDirectoryService provides read access to the faculty directory for external clients.
+type UserDirectoryService struct {
+	db *gorm.DB
+}
+
+// NewUserDirectoryService instantiates the service, falling back to the global config.DB.
+func NewUserDirectoryService(db *gorm.DB) *UserDirectoryService {
+	if db == nil {
+		db = config.DB
+	}
+	return &UserDirectoryService{db: db}
+}
+
+// ListForPartner returns paginated faculty records for the external users endpoint. It
+// excludes soft-deleted users (delete_at IS NULL). When updatedSince is non-nil, only users
+// modified at/after that time are returned (incremental sync). Returns rows + total count.
+func (s *UserDirectoryService) ListForPartner(updatedSince *time.Time, limit, offset int) ([]PartnerUser, int64, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	if limit > 500 {
+		limit = 500
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	// Build a fresh base query per finisher to avoid reusing a mutated statement.
+	buildBase := func() *gorm.DB {
+		q := s.db.Table("users AS u").
+			Joins("LEFT JOIN roles AS r ON r.role_id = u.role_id").
+			Where("u.delete_at IS NULL")
+		if updatedSince != nil {
+			q = q.Where("u.update_at >= ?", *updatedSince)
+		}
+		return q
+	}
+
+	var total int64
+	if err := buildBase().Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	if total == 0 {
+		return []PartnerUser{}, 0, nil
+	}
+
+	var rows []PartnerUser
+	if err := buildBase().
+		Select(partnerUserSelect).
+		Order("u.user_id").
+		Limit(limit).
+		Offset(offset).
+		Scan(&rows).Error; err != nil {
+		return nil, 0, err
+	}
+
+	return rows, total, nil
+}

--- a/services/user_directory_service_test.go
+++ b/services/user_directory_service_test.go
@@ -1,0 +1,45 @@
+package services
+
+import (
+	"database/sql/driver"
+	"regexp"
+	"testing"
+)
+
+func TestUserDirectoryListForPartnerBuildsQueries(t *testing.T) {
+	countPattern := regexp.MustCompile(`(?is)SELECT count\(\*\) FROM users AS u LEFT JOIN roles AS r.*u\.delete_at IS NULL`)
+	listPattern := regexp.MustCompile(`(?is)SELECT u\.user_id.*FROM users AS u LEFT JOIN roles AS r.*u\.delete_at IS NULL.*LIMIT \?`)
+
+	steps := []*queryStep{
+		{
+			kind:    kindQuery,
+			pattern: countPattern,
+			columns: []string{"count"},
+			rows:    [][]driver.Value{{int64(2)}},
+		},
+		{
+			kind:    kindQuery,
+			pattern: listPattern,
+			args:    []driver.Value{int64(5)},
+			columns: []string{"user_id"},
+			rows:    [][]driver.Value{},
+		},
+	}
+
+	db, state, cleanup := newScriptedGormDB(t, steps)
+	defer cleanup()
+
+	items, total, err := NewUserDirectoryService(db).ListForPartner(nil, 5, 0)
+	if err != nil {
+		t.Fatalf("ListForPartner returned error: %v", err)
+	}
+	if total != 2 {
+		t.Fatalf("expected total 2, got %d", total)
+	}
+	if len(items) != 0 {
+		t.Fatalf("expected no mapped rows from the empty result set, got %d", len(items))
+	}
+	if err := state.verifyComplete(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
Second external endpoint on the `/api/ext/v1` subsystem.

- `GET /api/ext/v1/users` — flat, paginated list of all non-deleted faculty; optional `updated_since` (RFC3339) for incremental sync. New scope `users.read` (migration `036`, seed only, no new tables).
- Reuses the existing API-key auth, `RequireScope`, rate limit, and audit-log middleware. New `UserDirectoryService.ListForPartner` (users LEFT JOIN roles, `delete_at IS NULL`).
- Docs: consumer guide `EXTERNAL_USERS_API.md` + operator/PII notes.

## Verified (live, intern DB, HTTP)
- 200 full (52 users) + incremental subset; 422/401 cases; clean field mapping (role_name join, omitempty). Existing Scopus endpoint unaffected. `go build/vet/test` pass.

## Deploy note
Prod needs migrations **035 + 036** run, and HTTPS enforced at the proxy.