### PR TITLE
feat: exclude test/system accounts from external /users

### DIFF
--- a/docs/EXTERNAL_API_SCOPUS_INTERNAL.md
+++ b/docs/EXTERNAL_API_SCOPUS_INTERNAL.md
@@ -28,7 +28,16 @@ api_clients/api_keys/middleware here — no new tables.**
 ⚠️ **PII:** the `/users` endpoint returns `email` and `tel` (personal contact data). Grant
 `users.read` only to clients authorized to receive it, and record that in the client's contact
 notes. The faculty directory (`ListForPartner` in `services/user_directory_service.go`) excludes
-soft-deleted users (`delete_at IS NULL`) and never returns passwords.
+soft-deleted users (`delete_at IS NULL`), **test/system accounts (`is_test = 0`)**, and never
+returns passwords.
+
+**Hiding test/system accounts:** migration 037 adds `users.is_test` (tinyint, default 0). The
+`/users` endpoint returns only `is_test = 0` rows. Flag accounts to hide them, e.g.:
+```sql
+UPDATE users SET is_test = 1 WHERE email IN ('testteacher@cpkku.ac.th', 'testadmin@cpkku.ac.th', ...);
+```
+This marker is currently consumed only by the external `/users` endpoint; other parts of the
+system are not yet filtering on it.
 
 ## Database schema (migration `035_20260809_create_api_client_tables.sql`)
 

--- a/docs/EXTERNAL_USERS_API.md
+++ b/docs/EXTERNAL_USERS_API.md
@@ -35,8 +35,8 @@ Authorization: Bearer <your-api-key>
 GET /api/ext/v1/users
 ```
 
-Returns a **flat, paginated** list of faculty. Soft-deleted (removed) users are excluded. Each
-record's stable key is `user_id`.
+Returns a **flat, paginated** list of faculty. Soft-deleted users and internal test/system
+accounts are excluded automatically. Each record's stable key is `user_id`.
 
 ### Query parameters
 

--- a/migrations/037_20260812_add_is_test_to_users.sql
+++ b/migrations/037_20260812_add_is_test_to_users.sql
@@ -1,0 +1,10 @@
+-- Add a test/system-account marker to users. The external faculty directory
+-- (GET /api/ext/v1/users) returns only is_test = 0 rows, so operators can hide
+-- test/dev/system accounts from external consumers without deleting them.
+--
+-- Flagging specific accounts is done by the operator, e.g.:
+--   UPDATE users SET is_test = 1 WHERE email IN ('testteacher@cpkku.ac.th', ...);
+-- This migration only adds the column (defaults everyone to 0 = not test).
+
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS is_test tinyint(1) NOT NULL DEFAULT 0 AFTER Is_active;

--- a/services/user_directory_service.go
+++ b/services/user_directory_service.go
@@ -63,8 +63,9 @@ func NewUserDirectoryService(db *gorm.DB) *UserDirectoryService {
 }
 
 // ListForPartner returns paginated faculty records for the external users endpoint. It
-// excludes soft-deleted users (delete_at IS NULL). When updatedSince is non-nil, only users
-// modified at/after that time are returned (incremental sync). Returns rows + total count.
+// excludes soft-deleted users (delete_at IS NULL) and test/system accounts (is_test = 0).
+// When updatedSince is non-nil, only users modified at/after that time are returned
+// (incremental sync). Returns rows + total count.
 func (s *UserDirectoryService) ListForPartner(updatedSince *time.Time, limit, offset int) ([]PartnerUser, int64, error) {
 	if limit <= 0 {
 		limit = 100
@@ -80,7 +81,8 @@ func (s *UserDirectoryService) ListForPartner(updatedSince *time.Time, limit, of
 	buildBase := func() *gorm.DB {
 		q := s.db.Table("users AS u").
 			Joins("LEFT JOIN roles AS r ON r.role_id = u.role_id").
-			Where("u.delete_at IS NULL")
+			Where("u.delete_at IS NULL").
+			Where("u.is_test = 0")
 		if updatedSince != nil {
 			q = q.Where("u.update_at >= ?", *updatedSince)
 		}

--- a/services/user_directory_service_test.go
+++ b/services/user_directory_service_test.go
@@ -7,8 +7,8 @@ import (
 )
 
 func TestUserDirectoryListForPartnerBuildsQueries(t *testing.T) {
-	countPattern := regexp.MustCompile(`(?is)SELECT count\(\*\) FROM users AS u LEFT JOIN roles AS r.*u\.delete_at IS NULL`)
-	listPattern := regexp.MustCompile(`(?is)SELECT u\.user_id.*FROM users AS u LEFT JOIN roles AS r.*u\.delete_at IS NULL.*LIMIT \?`)
+	countPattern := regexp.MustCompile(`(?is)SELECT count\(\*\) FROM users AS u LEFT JOIN roles AS r.*u\.delete_at IS NULL.*u\.is_test = 0`)
+	listPattern := regexp.MustCompile(`(?is)SELECT u\.user_id.*FROM users AS u LEFT JOIN roles AS r.*u\.delete_at IS NULL.*u\.is_test = 0.*LIMIT \?`)
 
 	steps := []*queryStep{
 		{


### PR DESCRIPTION
## Summary
Adds `users.is_test` (migration 037, tinyint default 0) and filters the external faculty directory (`GET /api/ext/v1/users`) to `is_test = 0`. Operators flag test/dev/system accounts (`UPDATE users SET is_test = 1 WHERE ...`) to hide them from external consumers without deleting them. Only the external `/users` endpoint consumes this marker for now.

## Verified (live, intern DB)
`/users` total 52 → flag one → 51 (account gone) → unflag → 52. `go build/test` pass.

## Deploy note
Prod needs migration **037** run (035+036 already applied).